### PR TITLE
Add support for Roku authentication

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 yarl = ">=1.0,<2.0"
 
 [package.extras]
-speedups = ["aiodns", "brotli", "cchardet"]
+speedups = ["Brotli", "aiodns", "cchardet"]
 
 [[package]]
 name = "aiosignal"
@@ -71,10 +71,42 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
+
+[[package]]
+name = "boto3"
+version = "1.23.10"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.26.10,<1.27.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.5.0,<0.6.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.26.10"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.13.8)"]
 
 [[package]]
 name = "cchardet"
@@ -104,7 +136,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "frozenlist"
@@ -132,6 +164,14 @@ python-versions = "*"
 
 [package.dependencies]
 idna = ">=2.0"
+
+[[package]]
+name = "jmespath"
+version = "0.10.0"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "multidict"
@@ -172,12 +212,58 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "s3transfer"
+version = "0.5.2"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "urllib3"
+version = "1.26.13"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "yarl"
@@ -195,7 +281,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "3c5523e1efb0bf1c4fdac689caf3a2b68980b1ae28f5d87c4bde3e292dde04c4"
+content-hash = "e4850c4d0918423691433c96f63c4e317b48bc3c366f0ebfef50ca4dd426d498"
 
 [metadata.files]
 aiodns = [
@@ -291,6 +377,14 @@ asynctest = [
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+boto3 = [
+    {file = "boto3-1.23.10-py3-none-any.whl", hash = "sha256:40d08614f17a69075e175c02c5d5aab69a6153fd50e40fa7057b913ac7bf40e7"},
+    {file = "boto3-1.23.10.tar.gz", hash = "sha256:2a4395e3241c20eef441d7443a5e6eaa0ee3f7114653fb9d9cef41587526f7bd"},
+]
+botocore = [
+    {file = "botocore-1.26.10-py3-none-any.whl", hash = "sha256:8a4a984bf901ccefe40037da11ba2abd1ddbcb3b490a492b7f218509c99fc12f"},
+    {file = "botocore-1.26.10.tar.gz", hash = "sha256:5df2cf7ebe34377470172bd0bbc582cf98c5cbd02da0909a14e9e2885ab3ae9c"},
 ]
 cchardet = [
     {file = "cchardet-2.1.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c6f70139aaf47ffb94d89db603af849b82efdf756f187cdd3e566e30976c519f"},
@@ -460,6 +554,10 @@ idna = [
 idna-ssl = [
     {file = "idna-ssl-1.1.0.tar.gz", hash = "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"},
 ]
+jmespath = [
+    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
+    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
+]
 multidict = [
     {file = "multidict-5.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3822c5894c72e3b35aae9909bef66ec83e44522faf767c0ad39e0e2de11d3b55"},
     {file = "multidict-5.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:28e6d883acd8674887d7edc896b91751dc2d8e87fbdca8359591a13872799e4e"},
@@ -603,9 +701,25 @@ pycryptodome = [
     {file = "pycryptodome-3.14.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:7fb90a5000cc9c9ff34b4d99f7f039e9c3477700e309ff234eafca7b7471afc0"},
     {file = "pycryptodome-3.14.1.tar.gz", hash = "sha256:e04e40a7f8c1669195536a37979dd87da2c32dbdc73d6fe35f0077b0c17c803b"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+s3transfer = [
+    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
+    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc"},
+    {file = "urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"},
 ]
 yarl = [
     {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ aiohttp = "^3.7"
 aiodns = "^3.0.0"
 cchardet = "^2.1.7"
 pycryptodome = "^3.12.0"
+boto3 = "^1.23.10"  # Roku login process
 
 [tool.poetry.dev-dependencies]
 

--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -7,29 +7,38 @@ import logging
 from inspect import iscoroutinefunction
 from typing import List, Optional, Set, Callable
 
-from .const import PHONE_SYSTEM_TYPE, APP_VERSION, SC, APP_VER, SV, PHONE_ID, APP_NAME, OLIVE_APP_ID, APP_INFO
+from .const import PHONE_ID, OLIVE_APP_ID
 from .crypto import olive_create_signature
 from .exceptions import TwoFactorAuthenticationEnabled
 from .payload_factory import olive_create_user_info_payload
-from .services.base_service import BaseService
-from .services.bulb_service import BulbService
-from .services.camera_service import CameraService
-from .services.hms_service import HMSService
-from .services.lock_service import LockService
-from .services.sensor_service import SensorService
-from .services.switch_service import SwitchService
-from .services.thermostat_service import ThermostatService
-from .services.wall_switch_service import WallSwitchService
+from .services.base_service import BaseService, RokuBaseService
+from .services.bulb_service import BulbService, RokuBulbService
+from .services.camera_service import CameraService, RokuCameraService
+from .services.hms_service import HMSService, RokuHMSService
+from .services.lock_service import LockService, RokuLockService
+from .services.sensor_service import SensorService, RokuSensorService
+from .services.switch_service import SwitchService, RokuSwitchService
+from .services.thermostat_service import ThermostatService, RokuThermostatService
+from .services.wall_switch_service import WallSwitchService, RokuWallSwitchService
 from .utils import check_for_errors_standard
-from .wyze_auth_lib import WyzeAuthLib, Token
+from .wyze_auth_lib import WyzeAuthLib, Token, RokuAuthLib
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class Wyzeapy:
     """A module to assist developers in interacting with the Wyze service"""
-    # _client: Client
     _auth_lib: WyzeAuthLib
+    _auth_lib_type = WyzeAuthLib
+    _base_service_type = BaseService
+    _bulb_service_type = BulbService
+    _switch_service_type = SwitchService
+    _camera_service_type = CameraService
+    _thermostat_service_type = ThermostatService
+    _hms_service_type = HMSService
+    _lock_service_type = LockService
+    _sensor_service_type = SensorService
+    _wall_switch_service_type = WallSwitchService
 
     def __init__(self):
         self._bulb_service = None
@@ -72,14 +81,16 @@ class Wyzeapy:
         try:
             if token:
                 # User token supplied, lets go ahead and use it and refresh the access token if needed.
-                self._auth_lib = await WyzeAuthLib.create(
+                self._auth_lib = await self._auth_lib_type.create(
                     email, password, token, token_callback=self.execute_token_callbacks)
                 await self._auth_lib.refresh_if_should()
-                self._service = BaseService(self._auth_lib)
+                self._service = self._base_service_type(self._auth_lib)
             else:
-                self._auth_lib = await WyzeAuthLib.create(email, password, token_callback=self.execute_token_callbacks)
+                self._auth_lib = await self._auth_lib_type.create(
+                    email, password, token_callback=self.execute_token_callbacks
+                )
                 await self._auth_lib.get_token_with_username_password(email, password)
-                self._service = BaseService(self._auth_lib)
+                self._service = self._base_service_type(self._auth_lib)
         except TwoFactorAuthenticationEnabled as error:
             raise error
 
@@ -94,7 +105,7 @@ class Wyzeapy:
         _LOGGER.debug(f"Verification Code: {verification_code}")
 
         await self._auth_lib.get_token_with_2fa(verification_code)
-        self._service = BaseService(self._auth_lib)
+        self._service = self._base_service_type(self._auth_lib)
         return self._auth_lib.token
 
     async def execute_token_callbacks(self, token: Token):
@@ -182,7 +193,7 @@ class Wyzeapy:
         """Returns an instance of the bulb service"""
 
         if self._bulb_service is None:
-            self._bulb_service = BulbService(self._auth_lib)
+            self._bulb_service = self._bulb_service_type(self._auth_lib)
         return self._bulb_service
 
     @property
@@ -190,7 +201,7 @@ class Wyzeapy:
         """Returns an instance of the switch service"""
 
         if self._switch_service is None:
-            self._switch_service = SwitchService(self._auth_lib)
+            self._switch_service = self._switch_service_type(self._auth_lib)
         return self._switch_service
 
     @property
@@ -198,7 +209,7 @@ class Wyzeapy:
         """Returns an instance of the camera service"""
 
         if self._camera_service is None:
-            self._camera_service = CameraService(self._auth_lib)
+            self._camera_service = self._camera_service_type(self._auth_lib)
         return self._camera_service
 
     @property
@@ -206,7 +217,7 @@ class Wyzeapy:
         """Returns an instance of the thermostat service"""
 
         if self._thermostat_service is None:
-            self._thermostat_service = ThermostatService(self._auth_lib)
+            self._thermostat_service = self._thermostat_service_type(self._auth_lib)
         return self._thermostat_service
 
     @property
@@ -214,7 +225,7 @@ class Wyzeapy:
         """Returns an instance of the hms service"""
 
         if self._hms_service is None:
-            self._hms_service = await HMSService.create(self._auth_lib)
+            self._hms_service = await self._hms_service_type.create(self._auth_lib)
         return self._hms_service
 
     @property
@@ -222,7 +233,7 @@ class Wyzeapy:
         """Returns an instance of the lock service"""
 
         if self._lock_service is None:
-            self._lock_service = LockService(self._auth_lib)
+            self._lock_service = self._lock_service_type(self._auth_lib)
         return self._lock_service
 
     @property
@@ -230,7 +241,7 @@ class Wyzeapy:
         """Returns an instance of the sensor service"""
 
         if self._sensor_service is None:
-            self._sensor_service = SensorService(self._auth_lib)
+            self._sensor_service = self._sensor_service_type(self._auth_lib)
         return self._sensor_service
 
     @property
@@ -238,5 +249,19 @@ class Wyzeapy:
         """Returns an instance of the switch service"""
 
         if self._wall_switch_service is None:
-            self._wall_switch_service = WallSwitchService(self._auth_lib)
+            self._wall_switch_service = self._wall_switch_service_type(self._auth_lib)
         return self._wall_switch_service
+
+
+class Rokuapy(Wyzeapy):
+    _auth_lib: RokuAuthLib
+    _auth_lib_type = RokuAuthLib
+    _base_service_type = RokuBaseService
+    _bulb_service_type = RokuBulbService
+    _switch_service_type = RokuSwitchService
+    _camera_service_type = RokuCameraService
+    _thermostat_service_type = RokuThermostatService
+    _hms_service_type = RokuHMSService
+    _lock_service_type = RokuLockService
+    _sensor_service_type = RokuSensorService
+    _wall_switch_service_type = RokuWallSwitchService

--- a/src/wyzeapy/const.py
+++ b/src/wyzeapy/const.py
@@ -6,15 +6,8 @@
 import uuid
 
 # Here is where all the *magic* lives
-PHONE_SYSTEM_TYPE = "1"
 API_KEY = "WMXHYf79Nr5gIlt3r0r7p9Tcw5bvs6BB4U8O8nGJ"
-APP_VERSION = "2.18.43"
-APP_VER = "com.hualai.WyzeCam___2.18.43"
-APP_NAME = "com.hualai.WyzeCam"
 PHONE_ID = str(uuid.uuid4())
-APP_INFO = 'wyze_android_2.19.14'  # Required for the thermostat
-SC = "9f275790cab94a72bd206c8876429f3c"
-SV = "9d74946e652647e9b6c9d59326aef104"
 
 # Crypto secrets
 OLIVE_SIGNING_SECRET = 'wyze_app_secret_key_132'  # Required for the thermostat

--- a/src/wyzeapy/services/bulb_service.py
+++ b/src/wyzeapy/services/bulb_service.py
@@ -7,7 +7,7 @@ import logging
 import re
 from typing import Any, Dict, Optional, List
 
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 from ..types import Device, PropertyIDs, DeviceTypes
 from ..utils import create_pid_pair
 
@@ -211,3 +211,5 @@ class BulbService(BaseService):
         await self._run_action_list(bulb, plist)
 
 
+class RokuBulbService(BulbService, RokuBaseService):
+    pass

--- a/src/wyzeapy/services/camera_service.py
+++ b/src/wyzeapy/services/camera_service.py
@@ -12,7 +12,7 @@ from typing import Any, List, Optional, Dict, Callable, Tuple
 from aiohttp import ClientOSError, ContentTypeError
 
 from ..exceptions import UnknownApiError
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 from .update_manager import DeviceUpdater
 from ..types import Device, DeviceTypes, Event, PropertyIDs
 from ..utils import return_event_for_device, create_pid_pair
@@ -142,3 +142,7 @@ class CameraService(BaseService):
     async def turn_off_motion_detection(self, camera: Camera):
         await self._set_property(camera, PropertyIDs.MOTION_DETECTION_TOGGLE.value, "1")
         await self._set_property(camera, PropertyIDs.MOTION_DETECTION_TOGGLE.value, "0")
+
+
+class RokuCameraService(CameraService, RokuBaseService):
+    pass

--- a/src/wyzeapy/services/hms_service.py
+++ b/src/wyzeapy/services/hms_service.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Optional
 
 from ..wyze_auth_lib import WyzeAuthLib
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 
 
 class HMSMode(Enum):
@@ -79,10 +79,5 @@ class HMSService(BaseService):
         return None
 
 
-
-
-
-
-
-
-
+class RokuHMSService(HMSService, RokuBaseService):
+    pass

--- a/src/wyzeapy/services/lock_service.py
+++ b/src/wyzeapy/services/lock_service.py
@@ -3,7 +3,7 @@
 #  of the attached license. You should have received a copy of
 #  the license with this file. If not, please write to:
 #  joshua@mulliken.net to receive a copy
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 from ..types import Device, DeviceTypes
 
 
@@ -42,3 +42,7 @@ class LockService(BaseService):
 
     async def unlock(self, lock: Lock):
         await self._lock_control(lock, "remoteUnlock")
+
+
+class RokuLockService(LockService, RokuBaseService):
+    pass

--- a/src/wyzeapy/services/sensor_service.py
+++ b/src/wyzeapy/services/sensor_service.py
@@ -11,7 +11,7 @@ from typing import List, Callable, Tuple, Optional
 from aiohttp import ClientOSError, ContentTypeError
 
 from ..exceptions import UnknownApiError
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 from ..types import Device, PropertyIDs, DeviceTypes
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,3 +78,7 @@ class SensorService(BaseService):
                    device.type is DeviceTypes.MOTION_SENSOR or
                    device.type is DeviceTypes.CONTACT_SENSOR]
         return [Sensor(sensor.raw_dict) for sensor in sensors]
+
+
+class RokuSensorService(SensorService, RokuBaseService):
+    pass

--- a/src/wyzeapy/services/switch_service.py
+++ b/src/wyzeapy/services/switch_service.py
@@ -5,7 +5,7 @@
 #  joshua@mulliken.net to receive a copy
 from typing import List, Dict, Any
 
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 from ..types import Device, DeviceTypes, PropertyIDs
 
 
@@ -44,3 +44,7 @@ class SwitchService(BaseService):
 
     async def turn_off(self, switch: Switch):
         await self._set_property(switch, PropertyIDs.ON.value, "0")
+
+
+class RokuSwitchService(SwitchService, RokuBaseService):
+    pass

--- a/src/wyzeapy/services/thermostat_service.py
+++ b/src/wyzeapy/services/thermostat_service.py
@@ -7,7 +7,7 @@ import logging
 from enum import Enum
 from typing import Any, Dict, List
 
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 from ..types import Device, ThermostatProps, DeviceTypes
 
 _LOGGER = logging.getLogger(__name__)
@@ -126,3 +126,7 @@ class ThermostatService(BaseService):
     async def _thermostat_set_iot_prop(self, device: Device, prop: ThermostatProps, value: Any) -> None:
         url = "https://wyze-earth-service.wyzecam.com/plugin/earth/set_iot_prop_by_topic"
         return await self._set_iot_prop(url, device, prop.value, value)
+
+
+class RokuThermostatService(ThermostatService, RokuBaseService):
+    pass

--- a/src/wyzeapy/services/wall_switch_service.py
+++ b/src/wyzeapy/services/wall_switch_service.py
@@ -7,7 +7,7 @@ import logging
 from enum import Enum
 from typing import Any, Dict, List
 
-from .base_service import BaseService
+from .base_service import BaseService, RokuBaseService
 from ..types import Device, WallSwitchProps, DeviceTypes
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,3 +109,7 @@ class WallSwitchService(BaseService):
     async def _wall_switch_set_iot_prop(self, device: Device, prop: WallSwitchProps, value: Any) -> None:
         url = "https://wyze-sirius-service.wyzecam.com//plugin/sirius/set_iot_prop_by_topic"
         return await self._set_iot_prop(url, device, prop.value, value)
+
+
+class RokuWallSwitchService(WallSwitchService, RokuBaseService):
+    pass

--- a/tests/test_roku.py
+++ b/tests/test_roku.py
@@ -1,0 +1,144 @@
+#  Copyright (c) 2021. Mulliken, LLC - All Rights Reserved
+#  You may use, distribute and modify this code under the terms
+#  of the attached license. You should have received a copy of
+#  the license with this file. If not, please write to:
+#  joshua@mulliken.net to receive a copy
+import asyncio
+import os
+import time
+import unittest
+
+from wyzeapy import Rokuapy
+from wyzeapy.services.bulb_service import Bulb, RokuBulbService
+from wyzeapy.services.camera_service import RokuCameraService
+from wyzeapy.services.switch_service import RokuSwitchService
+from wyzeapy.types import DeviceTypes
+
+USERNAME = os.getenv("ROKU_EMAIL")
+PASSWORD = os.getenv("ROKU_PASSWORD")
+
+
+async def login() -> Rokuapy:
+    client = await Rokuapy.create()
+    await client.login(USERNAME, PASSWORD)
+    return client
+
+
+class TestRokuClient(unittest.IsolatedAsyncioTestCase):
+    async def test_login(self):
+        client = await Rokuapy.create()
+        await client.login(USERNAME, PASSWORD)
+
+    async def test_valid_login(self):
+        assert await Rokuapy.valid_login(USERNAME, PASSWORD)
+
+    async def test_notifications_are_on(self):
+        client = await login()
+        await client.enable_notifications()
+        assert await client.notifications_are_on
+
+    async def test_get_device_ids(self):
+        client = await login()
+        device_ids = await client.unique_device_ids
+        for id in device_ids:
+            print(id)
+
+    async def test_notifications_on(self):
+        client = await login()
+        await client.enable_notifications()
+
+    async def test_notifications_off(self):
+        client = await login()
+        await client.disable_notifications()
+
+    async def test_refresh(self):
+        client = await Rokuapy.create()
+        await client.login(USERNAME, PASSWORD)
+        client._auth_lib.token.last_login_time = time.time() - (65 * 60 * 60)
+        bulb_service = await client.bulb_service
+        for bulb in await bulb_service.get_bulbs():
+            print(bulb.nickname)
+
+        await client.async_close()
+
+    async def test_bulb_service(self):
+        client = await login()
+        assert type(await client.bulb_service) is RokuBulbService
+        await client.async_close()
+
+    async def test_switch_service(self):
+        client = await login()
+        assert type(await client.switch_service) is RokuSwitchService
+        await client.async_close()
+
+    async def test_camera_service(self):
+        client = await login()
+        assert type(await client.camera_service) is RokuCameraService
+        await client.async_close()
+
+
+class TestRokuBulbService(unittest.IsolatedAsyncioTestCase):
+    async def test_get_bulbs(self):
+        client = await login()
+        bulb_service = await client.bulb_service
+        bulbs = await bulb_service.get_bulbs()
+        for bulb in bulbs:
+            print(bulb)
+
+        await client.async_close()
+
+    async def test_turn_on_bulb(self):
+        client = await login()
+        bulb_service = await client.bulb_service
+        bulbs = await bulb_service.get_bulbs()
+        for bulb in bulbs:
+            await bulb_service.turn_on(bulb)
+
+        await client.async_close()
+
+    async def test_turn_off_bulb(self):
+        client = await login()
+        bulb_service = await client.bulb_service
+        bulbs = await bulb_service.get_bulbs()
+        for bulb in bulbs:
+            await bulb_service.turn_off(bulb)
+        await client.async_close()
+
+    async def test_set_color_temp(self):
+        client = await login()
+        bulb_service = await client.bulb_service
+        bulbs = await bulb_service.get_bulbs()
+        for bulb in bulbs:
+            await bulb_service.set_color_temp(bulb, 1800)
+        await client.async_close()
+
+    async def test_set_color(self):
+        client = await login()
+        bulb_service = await client.bulb_service
+        bulbs = await bulb_service.get_bulbs()
+        for bulb in bulbs:
+            if bulb.type == DeviceTypes.MESH_LIGHT:
+                await bulb_service.set_color(bulb, "0000FF")
+        await client.async_close()
+
+    async def test_set_brightness(self):
+        client = await login()
+        bulb_service = await client.bulb_service
+        bulbs = await bulb_service.get_bulbs()
+        brightness_tasks = []
+        for bulb in bulbs:
+            print(bulb.nickname)
+            brightness_tasks.append(bulb_service.set_brightness(bulb, 50))
+
+        await asyncio.gather(*brightness_tasks)
+        await client.async_close()
+
+    async def test_update(self):
+        client = await login()
+        bulb_service = await client.bulb_service
+        bulbs = await bulb_service.get_bulbs()
+        for bulb in bulbs:
+            updated_bulb = await bulb_service.update(bulb)
+            self.assertIsInstance(updated_bulb, Bulb)
+
+        await client.async_close()


### PR DESCRIPTION
This change adds:

- RokuAuthLib class that extends WyzeAuthLib and replaces the authentication logic to get the Wyze session token from the Roku authentication server
- RokuBaseService that uses Roku-specific `sc` and `sv` values when making Wyze API calls
- RokuBulbService, RokuSwitchService, etc. that extend the normal BulbService, SwitchService, etc. and RokuBaseService
- Test file for Roku authentication and control

I have tested the authentication process and controlling bulbs and both work perfectly. However, the Wyze test file (and therefore the Roku test file since it's mostly the same so far) reference an `async_close` method on the `Wyzeapy` and `Rokuapy` objects that doesn't seem to exist, and omit a `local_control` argument on the `turn_off`, `turn_on`, and `set_color` methods of the bulb classes. Adding `local_control=True` to these seems to work, but I didn't commit that because I don't know how it's intended to be used.

If this is merged, I plan to either: A) add a "use Roku authentication" switch to the Wyze HACS integration that allows switching to Roku mode, or, if the integration is not instanced B) maintain a fork of the Wyze HACS integration that uses Roku mode. Any input here is appreciated :)