### PR TITLE
Add API Key/ID support SecKatie/ha-wyzeapi#493

### DIFF
--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -65,9 +65,19 @@ class WyzeAuthLib:
     ]
     SANITIZE_STRING = "**Sanitized**"
 
-    def __init__(self, username=None, password=None, token: Token = None, token_callback=None):
+    def __init__(
+        self,
+        username=None,
+        password=None,
+        key_id=None,
+        api_key=None,
+        token: Optional[Token] = None,
+        token_callback=None,
+    ):
         self._username = username
         self._password = password
+        self._key_id = key_id
+        self._api_key = api_key
         self.token = token
         self.session_id = ""
         self.verification_id = ""
@@ -76,8 +86,23 @@ class WyzeAuthLib:
         self.token_callback = token_callback
 
     @classmethod
-    async def create(cls, username=None, password=None, token: Token = None, token_callback=None):
-        self = cls(username=username, password=password, token=token, token_callback=token_callback)
+    async def create(
+        cls,
+        username=None,
+        password=None,
+        key_id=None,
+        api_key=None,
+        token: Optional[Token] = None,
+        token_callback=None,
+    ):
+        self = cls(
+            username=username,
+            password=password,
+            key_id=key_id,
+            api_key=api_key,
+            token=token,
+            token_callback=token_callback,
+        )
 
         if self._username is None and self._password is None and self.token is None:
             raise AttributeError("Must provide a username, password or token")
@@ -87,22 +112,26 @@ class WyzeAuthLib:
 
         return self
 
-    async def get_token_with_username_password(self, username, password) -> Token:
+    async def get_token_with_username_password(
+        self, username, password, key_id, api_key
+    ) -> Token:
         self._username = username
         self._password = create_password(password)
-        login_payload = {
-            "email": self._username,
-            "password": self._password
-        }
+        self._key_id = key_id
+        self._api_key = api_key
+        login_payload = {"email": self._username, "password": self._password}
 
         headers = {
-            'Phone-Id': PHONE_ID,
-            'User-Agent': APP_INFO,
-            'X-API-Key': API_KEY,
+            "keyid": key_id,
+            "apikey": api_key,
+            "User-Agent": "wyzeapy",
         }
 
-        response_json = await self.post("https://auth-prod.api.wyze.com/user/login", headers=headers,
-                                        json=login_payload)
+        response_json = await self.post(
+            "https://auth-prod.api.wyze.com/api/user/login",
+            headers=headers,
+            json=login_payload,
+        )
 
         if response_json.get('errorCode') is not None:
             _LOGGER.error(f"Unable to login with response from Wyze: {response_json}")


### PR DESCRIPTION
This PR will utilize the newer `/api/user/login` API endpoint for third-party authentication using `key_id` and `api_key` which can be generated on the developer portal: https://developer-api-console.wyze.com/#/apikey/view 

This change is necessary to ensure compatibility with the changes outlined here: https://support.wyze.com/hc/en-us/articles/16129834216731


Related issues: https://github.com/SecKatie/ha-wyzeapi/issues/493