### PR TITLE
Raise access token error on invalid credentials

### DIFF
--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -11,7 +11,11 @@ from typing import Dict, Any, Optional
 from aiohttp import TCPConnector, ClientSession, ContentTypeError
 
 from .const import API_KEY, PHONE_ID, APP_NAME, APP_VERSION, SC, SV, PHONE_SYSTEM_TYPE, APP_VER, APP_INFO
-from .exceptions import UnknownApiError, TwoFactorAuthenticationEnabled
+from .exceptions import (
+    UnknownApiError,
+    TwoFactorAuthenticationEnabled,
+    AccessTokenError,
+)
 from .utils import create_password, check_for_errors_standard
 
 _LOGGER = logging.getLogger(__name__)
@@ -135,6 +139,8 @@ class WyzeAuthLib:
 
         if response_json.get('errorCode') is not None:
             _LOGGER.error(f"Unable to login with response from Wyze: {response_json}")
+            if response_json["errorCode"] == 1000:
+                raise AccessTokenError
             raise UnknownApiError(response_json)
 
         if response_json.get('mfa_options') is not None:


### PR DESCRIPTION
Right now invalid credentials raises an unknown api error, which is not very helpful in determining why a login failed. 

This raises an invalid authentication error and produces a cleaner error in HA instead of the runtime error. 