### PR TITLE
chore(pyproject.toml): Bumps version to 0.5.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wyzeapy"
-version = "0.5.22-1"
+version = "0.5.23"
 description = "A library for interacting with Wyze devices"
 authors = ["Katie Mulliken <katie@mulliken.net>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
Preparation for release of a new version of HA-WyzeAPI to possibly fix an HMS error.