### PR TITLE
Remove unneeded warning from wall switch 

### DIFF
--- a/src/wyzeapy/services/wall_switch_service.py
+++ b/src/wyzeapy/services/wall_switch_service.py
@@ -74,7 +74,6 @@ class WallSwitchService(BaseService):
         return [WallSwitch(switch.raw_dict) for switch in switches]
 
     async def turn_on(self, switch: WallSwitch):
-        logging.warn("%s", switch.single_press_type)
         if switch.single_press_type == SinglePressType.IOT:
             await self.iot_on(switch)
         else:


### PR DESCRIPTION
I’m guessing this was left in by mistake, don’t need to log a warning when a switch is turned on. 