### PR TITLE
Update exceptions to support HomeAssistantError

### DIFF
--- a/src/wyzeapy/exceptions.py
+++ b/src/wyzeapy/exceptions.py
@@ -26,8 +26,7 @@ class LoginError(Exception):
 
 
 class UnknownApiError(Exception):
-    def __init__(self, response_json: Dict[str, Any]):
-        super(UnknownApiError, self).__init__(str(response_json))
+    pass
 
 
 class TwoFactorAuthenticationEnabled(Exception):

--- a/src/wyzeapy/utils.py
+++ b/src/wyzeapy/utils.py
@@ -73,22 +73,23 @@ def create_password(password: str) -> str:
 
 
 def check_for_errors_standard(service, response_json: Dict[str, Any]) -> None:
-    if response_json['code'] != ResponseCodes.SUCCESS.value:
-        if response_json['code'] == ResponseCodes.PARAMETER_ERROR.value:
-            raise ParameterError(response_json)
-        elif response_json['code'] == ResponseCodes.ACCESS_TOKEN_ERROR.value:
+    response_code = response_json['code']
+    if response_code != ResponseCodes.SUCCESS.value:
+        if response_code == ResponseCodes.PARAMETER_ERROR.value:
+            raise ParameterError(response_code, response_json['msg'])
+        elif response_code == ResponseCodes.ACCESS_TOKEN_ERROR.value:
             service._auth_lib.token.expired = True
-            raise AccessTokenError("Access Token expired, attempting to refresh")
-        elif response_json['code'] == ResponseCodes.DEVICE_OFFLINE.value:
+            raise AccessTokenError(response_code, "Access Token expired, attempting to refresh")
+        elif response_code == ResponseCodes.DEVICE_OFFLINE.value:
             return
         else:
-            raise UnknownApiError(response_json)
+            raise UnknownApiError(response_code, response_json['msg'])
 
 
 def check_for_errors_lock(service, response_json: Dict[str, Any]) -> None:
     if response_json['ErrNo'] != 0:
         if response_json.get('code') == ResponseCodes.PARAMETER_ERROR.value:
-            raise ParameterError
+            raise ParameterError(response_json)
         elif response_json.get('code') == ResponseCodes.ACCESS_TOKEN_ERROR.value:
             service._auth_lib.token.expired = True
             raise AccessTokenError("Access Token expired, attempting to refresh")


### PR DESCRIPTION
Necessary change for supporting HAError in the other repo. 

`check_for_errors_standard` was updated to make exceptions more readable. I would update the others but I don't have any devices that use the lock, iot or hms services so I don't know what is returned in those cases. 