### PR TITLE
Update documentation to match previous code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ from wyzeapy import Wyzeapy
 
 async def async_main():
     client = await Wyzeapy.create()
-    await client.login("EMAIL", "PASSWORD")
+    await client.login(email="EMAIL", password="PASSWORD", key_id="KEY_ID", api_key="API_KEY")
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_main())
+    asyncio.run(async_main())
 ```
+Note: Visit the [Wyze developer console](https://developer-api-console.wyze.com/#/apikey/view) to generate an Key Id and Api Key.
 
 ## Thanks to:
 


### PR DESCRIPTION
Two changes:
* Added `key_id` and `api_key` to log method login (and added a note about where to generate them)
* Switched to asyncio.run in the example, since using `get_event_loop` to get a new event loop is deprecated.