### PR TITLE
fix(tests): add pytest-asyncio configuration for CI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,7 @@ dev = [
     "pytest>=7.0.0,<10.0.0",
     "coverage>=7.9.2",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
Add explicit pytest-asyncio configuration to pyproject.toml to ensure
consistent test behavior across different environments. This sets:
- asyncio_mode = "auto" to automatically detect and run async tests
- asyncio_default_fixture_loop_scope = "function" for proper fixture scoping

This fixes test failures in GitHub Actions that occurred due to implicit
pytest-asyncio configuration in newer versions of the library.