### PR TITLE
chore(deps): upgrade CodeQL Action from v3 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,13 +39,13 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v3
+        uses: github/codeql-action/init@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
         
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v3
+        uses: github/codeql-action/autobuild@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
 
       # Command-line programs to run using the OS shell.
       # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -58,5 +58,5 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v3
+        uses: github/codeql-action/analyze@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
         

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@f47c8e6a9bd05ef3ee422fc8d8663be7fe4bdc61 # v3.31.8
+        uses: github/codeql-action/upload-sarif@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Upgrade all CodeQL Action references from v3 to v4
- v3 will be deprecated in December 2026 per [GitHub changelog](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)
- Addresses Scorecard security finding about deprecated actions

## Changes

| File | Action |
|------|--------|
| `.github/workflows/codeql.yml` | Updated init, autobuild, and analyze to v4 |
| `.github/workflows/scorecard.yml` | Updated upload-sarif to v4 |

## Test plan

- [ ] Verify CodeQL workflow runs successfully on this PR
- [ ] Confirm Scorecard no longer flags this deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)