### PR TITLE
fix: use correct commit SHA for codeql-action v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,13 +39,13 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
+        uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
         
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
+        uses: github/codeql-action/autobuild@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
 
       # Command-line programs to run using the OS shell.
       # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -58,5 +58,5 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
+        uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
         

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@a4784f2dad6682d68cce8299ef20b1ca931bbdfb # v4
+        uses: github/codeql-action/upload-sarif@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Fix incorrect codeql-action v4 SHA that was causing Scorecard workflow failures
- The previous SHA (`a4784f2dad6682d68cce8299ef20b1ca931bbdfb`) was a tag object reference
- Updated to the correct commit SHA (`1b168cd39490f61582a9beae412bb7057a6b2c4e`)

## Issue

Scorecard workflow was failing with:
```
workflow verification failed: imposter commit: a4784f2dad6682d68cce8299ef20b1ca931bbdfb 
does not belong to github/codeql-action/upload-sarif
```

## Files Changed

- `.github/workflows/codeql.yml` - Fixed init, autobuild, analyze actions
- `.github/workflows/scorecard.yml` - Fixed upload-sarif action

## Test plan

- [ ] Verify Scorecard workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)