### PR TITLE
fix: configure CodeQL for Python language analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,16 +31,18 @@ jobs:
 
     strategy:
       fail-fast: false
-      
+      matrix:
+        language: [ 'python' ]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
-        
+        with:
+          languages: ${{ matrix.language }}
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
@@ -59,4 +61,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
-        
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- Configure CodeQL to properly analyze Python code
- The language matrix was previously empty, causing incomplete analysis

## Changes

- Added `python` to the language matrix
- Pass `languages` parameter to the init step
- Added `category` to analyze step for better reporting  
- Updated checkout action to v4.2.2

## Why This Matters

This should fix the Scorecard SAST detection issue. The check looks for 
`github/codeql-action` usage and verifies it runs on PRs. With proper 
Python configuration, CodeQL will now:

1. Run on all PRs to main
2. Properly analyze Python source code
3. Report findings to GitHub's code scanning dashboard

## Test plan

- [ ] Verify CodeQL workflow runs successfully with Python analysis
- [ ] Check that Scorecard SAST score improves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)