### PR TITLE
fix: pin auto-approve-action to commit SHA

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.event.pull_request.user.login == github.repository_owner
     steps:
       - name: Auto Approve
-        uses: hmarr/auto-approve-action@v4
+        uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin `hmarr/auto-approve-action` to commit SHA `8f929096a962e83ccdfa8afcf855f39f12d4dac7` (v4) for supply chain security.

## Why

- Addresses Scorecard Pinned-Dependencies check
- Prevents supply chain attacks via tag mutation
- Best practice for GitHub Actions security

🤖 Generated with [Claude Code](https://claude.com/claude-code)