### PR TITLE
Prepare 0.5.32rc1 prerelease

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,10 @@ name: "CodeQL"
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop", "release/*" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main", "develop", "release/*" ]
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, release/* ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, release/* ]
 
 permissions:
   contents: read
@@ -25,13 +25,10 @@ jobs:
       uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
     - name: Install dependencies
-      run: |
-        uv pip install --system ruff
+      run: uv sync --group dev
 
     - name: Run ruff check
-      run: |
-        ruff check src/
+      run: uv run ruff check src/
 
     - name: Run ruff format check
-      run: |
-        ruff format --check src/
+      run: uv run ruff format --check src/

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: "${{ secrets.TEST_PYPI_TOKEN }}"
-        run: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+        run: twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,11 +30,14 @@ jobs:
       - name: Sync project dependencies
         run: uv sync --all-groups
 
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
       - name: Build distribution
-        run: uv run python -m build --sdist --wheel
+        run: python -m build --sdist --wheel
 
       - name: Publish package to Test PyPI
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: "${{ secrets.TEST_PYPI_TOKEN }}"
-        run: uv run twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+        run: twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, release/* ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, release/* ]
 
 permissions:
   contents: read
@@ -28,18 +28,15 @@ jobs:
       uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
     - name: Install dependencies
-      run: |
-        uv pip install --system -e .
-        uv pip install --system pytest pytest-asyncio coverage
+      run: uv sync --group dev
 
     - name: Run tests with coverage
       run: |
-        coverage run -m pytest tests/ -v
-        coverage report
+        uv run coverage run -m pytest tests/ -v
+        uv run coverage report
 
     - name: Generate coverage report
-      run: |
-        coverage xml
+      run: uv run coverage xml
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wyzeapy"
-version = "0.5.31"
+version = "0.5.32rc1"
 description = "A library for interacting with Wyze devices"
 authors = [
     { name = "Katie Mulliken", email = "katie@mulliken.net" },
@@ -13,19 +13,15 @@ dependencies = [
     "pycryptodome>=3.21.0,<4.0.0",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pdoc>=15.0.3,<17.0.0",
-    "pytest>=7.0.0,<10.0.0",
-]
-
 [build-system]
 requires = ["hatchling>=1.24"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "pdoc>=15.0.3,<17.0.0",
     "ruff>=0.12.3",
     "pytest>=7.0.0,<10.0.0",
+    "pytest-asyncio>=0.23.0,<2.0.0",
     "coverage>=7.9.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wyzeapy"
-version = "0.5.32rc1"
+version = "0.5.33rc1"
 description = "A library for interacting with Wyze devices"
 authors = [
     { name = "Katie Mulliken", email = "katie@mulliken.net" },

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "wyzeapy"
-version = "0.5.32rc1"
+version = "0.5.33rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },

--- a/uv.lock
+++ b/uv.lock
@@ -702,17 +702,31 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -751,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "wyzeapy"
-version = "0.5.31"
+version = "0.5.32rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },
@@ -759,16 +773,12 @@ dependencies = [
     { name = "pycryptodome" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "pdoc" },
-    { name = "pytest" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "pdoc" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -776,16 +786,15 @@ dev = [
 requires-dist = [
     { name = "aiodns", specifier = ">=3.2.0,<5.0.0" },
     { name = "aiohttp", specifier = ">=3.11.12,<4.0.0" },
-    { name = "pdoc", marker = "extra == 'dev'", specifier = ">=15.0.3,<17.0.0" },
     { name = "pycryptodome", specifier = ">=3.21.0,<4.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0,<10.0.0" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.9.2" },
+    { name = "pdoc", specifier = ">=15.0.3,<17.0.0" },
     { name = "pytest", specifier = ">=7.0.0,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0,<2.0.0" },
     { name = "ruff", specifier = ">=0.12.3" },
 ]
 


### PR DESCRIPTION
Summary:
- bump wyzeapy to 0.5.32rc1
- refresh uv.lock for the prerelease version and dev dependency alignment
- fix release, test, and lint workflows so release branches run checks and Test PyPI publish succeeds

Validation:
- GitHub Actions on release/0.5.32rc1 passed for Test, Lint, and Upload to Test PyPI
- uv build
- uv run pytest tests -v
- uv run ruff check src/
- uv run ruff format --check src/
