### PR TITLE
Add support for Wyze Cam Pan v4 (HL_PAN4)

### DIFF
--- a/src/wyzeapy/payload_factory.py
+++ b/src/wyzeapy/payload_factory.py
@@ -603,6 +603,82 @@ def devicemgmt_get_iot_props_list(model: str):
                     ],
                 },
             ]
+        case "HL_PAN4":  # Wyze Cam Pan v4
+            return [
+                {
+                    "iid": 2,
+                    "name": "camera",
+                    "properties": [
+                        "motion-detect",
+                        "resolution",
+                        "bit-rate",
+                        "live-stream-mode",
+                        "recording-mode",
+                        "frame-rate",
+                        "night-shot",
+                        "night-shot-state",
+                        "time-watermark",
+                        "logo-watermark",
+                        "cool-down-interval",
+                        "motion-push",
+                        "infrared-mode",
+                        "motion-detect-recording",
+                        "rotate-angle",
+                        "sound-collection-on",
+                    ],
+                },
+                {
+                    "iid": 3,
+                    "name": "device-info",
+                    "properties": [
+                        "device-id",
+                        "device-model",
+                        "firmware-ver",
+                        "mac",
+                        "timezone",
+                        "lat",
+                        "ip",
+                        "lon",
+                        "company-code",
+                        "hardware-ver",
+                        "public-ip",
+                    ],
+                },
+                {
+                    "iid": 1,
+                    "name": "iot-device",
+                    "properties": ["iot-state", "iot-power", "push-switch"],
+                },
+                {
+                    "iid": 12,
+                    "name": "camera-ai",
+                    "properties": ["smart-detection-type", "on"],
+                },
+                {"iid": 8, "name": "indicator-light", "properties": ["on", "mode"]},
+                {
+                    "iid": 6,
+                    "name": "motion-detection",
+                    "properties": [
+                        "sensitivity-motion",
+                        "on",
+                        "motion-zone",
+                        "motion-zone-block-size",
+                        "motion-zone-selected-block",
+                        "motion-tag",
+                    ],
+                },
+                {"iid": 4, "name": "siren", "properties": ["state", "siren-on-ts"]},
+                {
+                    "iid": 5,
+                    "name": "spotlight",
+                    "properties": ["on", "enabled", "brightness"],
+                },
+                {
+                    "iid": 9,
+                    "name": "wifi",
+                    "properties": ["on", "signal-strength", "wifi-ssid"],
+                },
+            ]
         case _:
             raise NotImplementedError(
                 f"No iot props for model ({model}) have been defined."

--- a/src/wyzeapy/services/camera_service.py
+++ b/src/wyzeapy/services/camera_service.py
@@ -30,7 +30,8 @@ DEVICEMGMT_API_MODELS = [
     "LD_CFP",
     "AN_RSCW",
     "GW_GC1",
-]  # Floodlight pro, battery cam pro, and OG use a diffrent api (devicemgmt)
+    "HL_PAN4",  # Wyze Cam Pan v4
+]  # Floodlight pro, battery cam pro, OG, and Pan v4 use a diffrent api (devicemgmt)
 
 
 class Camera(Device):
@@ -197,10 +198,10 @@ class CameraService(BaseService):
 
     # Also controls lamp socket, BCP spotlight, and Bulb Cam light
     async def floodlight_on(self, camera: Camera):
-        if camera.product_model == "AN_RSCW":
+        if camera.product_model in ("AN_RSCW", "HL_PAN4"):
             await self._run_action_devicemgmt(
                 camera, "spotlight", "1"
-            )  # Battery cam pro integrated spotlight is controllable
+            )  # Battery cam pro and Pan v4 have an integrated spotlight
         elif camera.product_model in DEVICEMGMT_API_MODELS:
             await self._run_action_devicemgmt(
                 camera, "floodlight", "1"
@@ -213,10 +214,10 @@ class CameraService(BaseService):
 
     # Also controls lamp socket, BCP spotlight, and Bulb Cam light
     async def floodlight_off(self, camera: Camera):
-        if camera.product_model == "AN_RSCW":
+        if camera.product_model in ("AN_RSCW", "HL_PAN4"):
             await self._run_action_devicemgmt(
                 camera, "spotlight", "0"
-            )  # Battery cam pro integrated spotlight is controllable
+            )  # Battery cam pro and Pan v4 have an integrated spotlight
         elif camera.product_model in DEVICEMGMT_API_MODELS:
             await self._run_action_devicemgmt(
                 camera, "floodlight", "0"


### PR DESCRIPTION
## Summary

Adds support for the **Wyze Cam Pan v4** (model identifier `HL_PAN4`).

Currently a `HL_PAN4` camera in the integration shows all entities as `unavailable` and toggling its power switch is silently ignored. The legacy `_run_action(camera, "power_on"/"power_off")` path against `https://api.wyzecam.com/app/v2/auto/run_action` is silently rejected by the cloud for `HL_PAN4` (the response contains `data.result: 3` and the device's `iot-power` flag never moves). The cloud expects this device on the newer `devicemgmt-service-beta.wyze.com` endpoint with the `iot-device.wakeup` / `iot-device.sleep` capability — the same path already wired for `LD_CFP` / `AN_RSCW` / `GW_GC1`.

## Changes

1. **`src/wyzeapy/services/camera_service.py`**: add `HL_PAN4` to `DEVICEMGMT_API_MODELS` so `turn_on` / `turn_off` (and the rest of the new-API code path used by `update()`, `siren_on/off`, etc.) route through `_run_action_devicemgmt` for the Pan v4.
2. **`src/wyzeapy/payload_factory.py`**: add an `HL_PAN4` case to `devicemgmt_get_iot_props_list` so the per-model state-poll request lists exactly the capability categories the cloud accepts for this device. Without this entry, polling raises `NotImplementedError`.
3. **`src/wyzeapy/services/camera_service.py` (`floodlight_on` / `floodlight_off`)**: extend the `AN_RSCW` spotlight branch to also cover `HL_PAN4`. Pan v4 has an integrated spotlight, not a floodlight, so dispatch needs the `spotlight` capability; sending the generic `floodlight` capability for `HL_PAN4` is silently rejected by the cloud (`code 1001 unsupported capability`).

## How the property list was determined

Discovered empirically by probing each capability category one-at-a-time against a live HL_PAN4 unit (`devicemgmt-service-beta.wyze.com/device-management/api/device-property/get_iot_prop`). Categories the cloud rejected with `code 1001 unsupported capability` were excluded:

- Excluded: `memory-card-management`, `pan-tilt`, `tracking`, `privacy`, `lens`, `motor`, `floodlight`, `pir`, `battery`.
- Accepted (included in this PR): `iot-device`, `camera`, `device-info`, `siren`, `spotlight`, `motion-detection`, `indicator-light`, `wifi`, `camera-ai`.

The property names in each category and the `iid` numbers are the values the cloud actually returned in the response, not copied from a sibling model. (One side-effect: HL_PAN4's `motion-detection` is at `iid: 6`, while `AN_RSCW` and `GW_GC1` have `motion-detection` at `iid: 11`. This is what the cloud reports for HL_PAN4 — leaving a note in case it looks like a copy-paste error.)

## Test plan

Tested end-to-end on a live HL_PAN4 attached to a Home Assistant install with the `wyzeapi` integration:

- [x] Before patch: `switch.<cam>_power`, `switch.<cam>_motion_detection`, `switch.<cam>_notifications`, `siren.<cam>_siren`, and `camera.wyzeapi_<id>` all `unavailable`. `turn_off` / `turn_on` services return success but iot-power never moves and the lens motor doesn't actuate.
- [x] After patch: all five entities populate with real cloud-reported state. `switch.turn_off` / `switch.turn_on` against `switch.<cam>_power` flips `iot-power` within ~5 seconds; the lens physically motors down for off and up for on (visually confirmed by the camera owner).
- [x] No regression on `LD_CFP`, `AN_RSCW`, `GW_GC1` — all four `devicemgmt_get_iot_props_list` cases still return their original lists; `floodlight_on`/`off` for `AN_RSCW` still routes to `spotlight` as before; non-DEVICEMGMT models continue to use the legacy `_run_action` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)