### PR TITLE
Add Wyze air purifier support

### DIFF
--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -8,6 +8,7 @@ from inspect import iscoroutinefunction
 from typing import List, Optional, Set, Callable
 
 from .exceptions import TwoFactorAuthenticationEnabled
+from .services.air_purifier_service import AirPurifierService
 from .services.base_service import BaseService
 from .services.bulb_service import BulbService
 from .services.camera_service import CameraService
@@ -52,6 +53,7 @@ class Wyzeapy:
         self._lock_service = None
         self._sensor_service = None
         self._irrigation_service = None
+        self._air_purifier_service = None
         self._wall_switch_service = None
         self._switch_usage_service = None
         self._email = None
@@ -451,6 +453,14 @@ class Wyzeapy:
         if self._irrigation_service is None:
             self._irrigation_service = IrrigationService(self._auth_lib)
         return self._irrigation_service
+
+    @property
+    async def air_purifier_service(self) -> AirPurifierService:
+        """Returns an instance of the air purifier service"""
+
+        if self._air_purifier_service is None:
+            self._air_purifier_service = AirPurifierService(self._auth_lib)
+        return self._air_purifier_service
 
     @property
     async def wall_switch_service(self) -> WallSwitchService:

--- a/src/wyzeapy/payload_factory.py
+++ b/src/wyzeapy/payload_factory.py
@@ -65,6 +65,16 @@ def olive_create_get_air_prop_payload(
     }
 
 
+def olive_create_query_air_history_payload(
+    device_mac: str, begin_time: int, last_time: int
+) -> Dict[str, Any]:
+    return {
+        "device_id": device_mac,
+        "begin_time": str(begin_time),
+        "last_time": str(last_time),
+    }
+
+
 def olive_create_get_payload_irrigation(device_mac: str) -> Dict[str, Any]:
     nonce = int(time.time() * 1000)
 

--- a/src/wyzeapy/payload_factory.py
+++ b/src/wyzeapy/payload_factory.py
@@ -52,6 +52,19 @@ def olive_create_get_payload(device_mac: str, keys: str) -> Dict[str, Any]:
     return {"keys": keys, "did": device_mac, "nonce": nonce}
 
 
+def olive_create_get_air_prop_payload(
+    device_mac: str, device_model: str, prop_names: str
+) -> Dict[str, Any]:
+    nonce = int(time.time() * 1000)
+
+    return {
+        "deviceId": device_mac,
+        "deviceModel": device_model,
+        "propNames": prop_names,
+        "nonce": nonce,
+    }
+
+
 def olive_create_get_payload_irrigation(device_mac: str) -> Dict[str, Any]:
     nonce = int(time.time() * 1000)
 

--- a/src/wyzeapy/services/air_purifier_service.py
+++ b/src/wyzeapy/services/air_purifier_service.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from enum import Enum
 from typing import Any, Dict, List
 
@@ -27,6 +28,9 @@ class AirPurifier(Device):
         self.available: bool = False
         self.fan_mode: str = AirPurifierFanMode.AUTO.value
         self.aqi: int | None = None
+        self.max_hourly_aqi: int | None = None
+        self.max_hourly_aqi_start_time: int | None = None
+        self.max_hourly_aqi_end_time: int | None = None
         self.app_version: str | None = None
         self.sn: str | None = None
         self.wifi_mac: str | None = None
@@ -72,7 +76,10 @@ class AirPurifierService(BaseService):
         response = await self._air_purifier_get_air_prop(air_purifier)
         settings = response.get("data", {}).get("settings", {})
         aqi = settings.get(AirPurifierProps.AQI.value)
-        air_purifier.aqi = int(aqi) if aqi is not None else None
+        air_purifier.aqi = self._parse_int(aqi)
+
+        await self._air_purifier_update_max_hourly_aqi(air_purifier)
+
         return air_purifier
 
     async def get_air_purifiers(self) -> List[AirPurifier]:
@@ -111,6 +118,52 @@ class AirPurifierService(BaseService):
     async def _air_purifier_get_air_prop(self, device: Device) -> Dict[Any, Any]:
         url = "https://wyze-earth-service.wyzecam.com/plugin/earth/get_air_prop"
         return await self._get_air_prop(url, device, AirPurifierProps.AQI.value)
+
+    async def _air_purifier_update_max_hourly_aqi(
+        self, air_purifier: AirPurifier
+    ) -> None:
+        begin_time, last_time = self._air_quality_hour()
+        response = await self._air_purifier_query_air_history(
+            air_purifier, begin_time=begin_time, last_time=last_time
+        )
+
+        air_purifier.max_hourly_aqi_start_time = begin_time
+        air_purifier.max_hourly_aqi_end_time = last_time
+        air_purifier.max_hourly_aqi = self._get_max_hourly_aqi(
+            response.get("data") or []
+        )
+
+    @staticmethod
+    def _air_quality_hour() -> tuple[int, int]:
+        last_time = int(time.time())
+        begin_time = last_time - (last_time % 3600)
+        return begin_time, last_time
+
+    @classmethod
+    def _get_max_hourly_aqi(cls, history: List[Dict[Any, Any]]) -> int | None:
+        for sample in reversed(history):
+            max_aqi = cls._parse_int(sample.get("max_aqi"))
+            avg_aqi = cls._parse_int(sample.get("avg"))
+            if max_aqi is not None and (
+                max_aqi > 0 or (avg_aqi is not None and avg_aqi >= 0)
+            ):
+                return max_aqi
+        return None
+
+    @staticmethod
+    def _parse_int(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def _air_purifier_query_air_history(
+        self, device: Device, begin_time: int, last_time: int
+    ) -> Dict[Any, Any]:
+        url = "https://wyze-earth-service.wyzecam.com/plugin/earth/query_air_history"
+        return await self._query_air_history(url, device, begin_time, last_time)
 
     async def _air_purifier_set_iot_prop(
         self, device: Device, prop: AirPurifierProps, value: Any

--- a/src/wyzeapy/services/air_purifier_service.py
+++ b/src/wyzeapy/services/air_purifier_service.py
@@ -1,0 +1,121 @@
+import logging
+from enum import Enum
+from typing import Any, Dict, List
+
+from .base_service import BaseService
+from ..types import AirPurifierProps, Device, DeviceTypes, PropertyIDs
+
+_LOGGER = logging.getLogger(__name__)
+
+AIR_PURIFIER_MODELS = {"CO_AP1"}
+
+
+class AirPurifierFanMode(Enum):
+    AUTO = "auto"
+    SLEEP = "sleep"
+    MIN = "min"
+    MID = "mid"
+    MAX = "max"
+    TURBO = "turbo"
+
+
+class AirPurifier(Device):
+    def __init__(self, dictionary: Dict[Any, Any]):
+        super().__init__(dictionary)
+
+        self.on: bool = False
+        self.available: bool = False
+        self.fan_mode: str = AirPurifierFanMode.AUTO.value
+        self.aqi: int | None = None
+        self.app_version: str | None = None
+        self.sn: str | None = None
+        self.wifi_mac: str | None = None
+
+
+class AirPurifierService(BaseService):
+    async def update(self, air_purifier: AirPurifier) -> AirPurifier:
+        """Update the air purifier with latest data from Wyze API."""
+        device_info = await self._get_property_list(air_purifier)
+        for property_id, value in device_info:
+            if property_id == PropertyIDs.ON:
+                air_purifier.on = value == "1"
+            elif property_id == PropertyIDs.AVAILABLE:
+                air_purifier.available = value == "1"
+
+        properties = (await self._air_purifier_get_iot_prop(air_purifier))["data"][
+            "props"
+        ]
+
+        device_props = []
+        for prop_key, prop_value in properties.items():
+            try:
+                prop = AirPurifierProps(prop_key)
+                device_props.append((prop, prop_value))
+            except ValueError as err:
+                _LOGGER.debug(f"{err} with value {prop_value}")
+
+        for prop, value in device_props:
+            if prop == AirPurifierProps.IOT_STATE:
+                air_purifier.available = value == "connected"
+            elif prop == AirPurifierProps.FAN_MODE:
+                air_purifier.fan_mode = value
+            elif prop == AirPurifierProps.APP_VERSION:
+                air_purifier.app_version = value
+            elif prop == AirPurifierProps.SN:
+                air_purifier.sn = value
+            elif prop == AirPurifierProps.WIFI_MAC:
+                air_purifier.wifi_mac = value
+
+        return air_purifier
+
+    async def update_air_quality(self, air_purifier: AirPurifier) -> AirPurifier:
+        response = await self._air_purifier_get_air_prop(air_purifier)
+        settings = response.get("data", {}).get("settings", {})
+        aqi = settings.get(AirPurifierProps.AQI.value)
+        air_purifier.aqi = int(aqi) if aqi is not None else None
+        return air_purifier
+
+    async def get_air_purifiers(self) -> List[AirPurifier]:
+        if self._devices is None:
+            self._devices = await self.get_object_list()
+
+        air_purifiers = [
+            device
+            for device in self._devices
+            if device.type is DeviceTypes.COMMON
+            and device.product_model in AIR_PURIFIER_MODELS
+        ]
+
+        return [AirPurifier(air_purifier.raw_dict) for air_purifier in air_purifiers]
+
+    async def turn_on(self, air_purifier: AirPurifier):
+        await self._set_property(air_purifier, PropertyIDs.ON.value, "1")
+
+    async def turn_off(self, air_purifier: AirPurifier):
+        await self._set_property(air_purifier, PropertyIDs.ON.value, "0")
+
+    async def set_fan_mode(
+        self, air_purifier: AirPurifier, fan_mode: AirPurifierFanMode | str
+    ) -> None:
+        if isinstance(fan_mode, AirPurifierFanMode):
+            fan_mode = fan_mode.value
+        await self._air_purifier_set_iot_prop(
+            air_purifier, AirPurifierProps.FAN_MODE, fan_mode
+        )
+
+    async def _air_purifier_get_iot_prop(self, device: Device) -> Dict[Any, Any]:
+        url = "https://wyze-earth-service.wyzecam.com/plugin/earth/get_iot_prop"
+        keys = "iot_state,fan_mode,app_version,sn,wifi_mac"
+        return await self._get_iot_prop(url, device, keys)
+
+    async def _air_purifier_get_air_prop(self, device: Device) -> Dict[Any, Any]:
+        url = "https://wyze-earth-service.wyzecam.com/plugin/earth/get_air_prop"
+        return await self._get_air_prop(url, device, AirPurifierProps.AQI.value)
+
+    async def _air_purifier_set_iot_prop(
+        self, device: Device, prop: AirPurifierProps, value: Any
+    ) -> None:
+        url = (
+            "https://wyze-earth-service.wyzecam.com/plugin/earth/set_iot_prop_by_topic"
+        )
+        return await self._set_iot_prop(url, device, prop.value, value)

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -33,6 +33,7 @@ from ..payload_factory import (
     olive_create_hms_payload,
     olive_create_hms_get_payload,
     ford_create_payload,
+    olive_create_get_air_prop_payload,
     olive_create_get_payload,
     olive_create_post_payload,
     olive_create_user_info_payload,
@@ -790,6 +791,31 @@ class BaseService:
         await self._auth_lib.refresh_if_should()
 
         payload = olive_create_get_payload(device.mac, keys)
+        signature = olive_create_signature(payload, self._auth_lib.token.access_token)
+        headers = {
+            "Accept-Encoding": "gzip",
+            "User-Agent": "myapp",
+            "appid": OLIVE_APP_ID,
+            "appinfo": APP_INFO,
+            "phoneid": PHONE_ID,
+            "access_token": self._auth_lib.token.access_token,
+            "signature2": signature,
+        }
+
+        response_json = await self._auth_lib.get(url, headers=headers, params=payload)
+
+        check_for_errors_iot(self, response_json)
+
+        return response_json
+
+    async def _get_air_prop(
+        self, url: str, device: Device, prop_names: str
+    ) -> Dict[Any, Any]:
+        await self._auth_lib.refresh_if_should()
+
+        payload = olive_create_get_air_prop_payload(
+            device.mac, device.product_model, prop_names
+        )
         signature = olive_create_signature(payload, self._auth_lib.token.access_token)
         headers = {
             "Accept-Encoding": "gzip",

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -35,6 +35,7 @@ from ..payload_factory import (
     ford_create_payload,
     olive_create_get_air_prop_payload,
     olive_create_get_payload,
+    olive_create_query_air_history_payload,
     olive_create_post_payload,
     olive_create_user_info_payload,
     devicemgmt_create_capabilities_payload,
@@ -815,6 +816,31 @@ class BaseService:
 
         payload = olive_create_get_air_prop_payload(
             device.mac, device.product_model, prop_names
+        )
+        signature = olive_create_signature(payload, self._auth_lib.token.access_token)
+        headers = {
+            "Accept-Encoding": "gzip",
+            "User-Agent": "myapp",
+            "appid": OLIVE_APP_ID,
+            "appinfo": APP_INFO,
+            "phoneid": PHONE_ID,
+            "access_token": self._auth_lib.token.access_token,
+            "signature2": signature,
+        }
+
+        response_json = await self._auth_lib.get(url, headers=headers, params=payload)
+
+        check_for_errors_iot(self, response_json)
+
+        return response_json
+
+    async def _query_air_history(
+        self, url: str, device: Device, begin_time: int, last_time: int
+    ) -> Dict[Any, Any]:
+        await self._auth_lib.refresh_if_should()
+
+        payload = olive_create_query_air_history_payload(
+            device.mac, begin_time, last_time
         )
         signature = olive_create_signature(payload, self._auth_lib.token.access_token)
         headers = {

--- a/src/wyzeapy/types.py
+++ b/src/wyzeapy/types.py
@@ -165,6 +165,15 @@ class IrrigationProps(Enum):
     SSID = "ssid"
 
 
+class AirPurifierProps(Enum):
+    AQI = "aqi"
+    IOT_STATE = "iot_state"  # Connection state: connected, disconnected
+    FAN_MODE = "fan_mode"
+    APP_VERSION = "app_version"
+    SN = "sn"
+    WIFI_MAC = "wifi_mac"
+
+
 class ResponseCodes(Enum):
     SUCCESS = "1"
     PARAMETER_ERROR = "1001"

--- a/tests/test_air_purifier_service.py
+++ b/tests/test_air_purifier_service.py
@@ -1,0 +1,208 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from wyzeapy.services.air_purifier_service import (
+    AirPurifier,
+    AirPurifierFanMode,
+    AirPurifierService,
+)
+from wyzeapy.types import AirPurifierProps, DeviceTypes, PropertyIDs
+from wyzeapy.wyze_auth_lib import WyzeAuthLib
+
+
+class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.mock_auth_lib = MagicMock(spec=WyzeAuthLib)
+        self.air_purifier_service = AirPurifierService(auth_lib=self.mock_auth_lib)
+        self.air_purifier_service._get_property_list = AsyncMock()
+        self.air_purifier_service._set_property = AsyncMock()
+        self.air_purifier_service._get_iot_prop = AsyncMock()
+        self.air_purifier_service._set_iot_prop = AsyncMock()
+        self.air_purifier_service._get_air_prop = AsyncMock()
+        self.air_purifier_service.get_object_list = AsyncMock()
+
+        self.test_air_purifier = AirPurifier(
+            {
+                "product_type": DeviceTypes.COMMON.value,
+                "product_model": "CO_AP1",
+                "mac": "AIRPURIFIER123",
+                "nickname": "Test Air Purifier",
+                "device_params": {"ip": "192.168.1.100"},
+                "raw_dict": {},
+            }
+        )
+
+    async def test_update_air_purifier(self):
+        self.air_purifier_service._get_property_list.return_value = [
+            (PropertyIDs.ON, "1"),
+            (PropertyIDs.AVAILABLE, "1"),
+        ]
+        self.air_purifier_service._get_iot_prop.return_value = {
+            "data": {
+                "props": {
+                    "iot_state": "connected",
+                    "fan_mode": "auto",
+                    "app_version": "1.0.18.0",
+                    "sn": "SN123456789",
+                    "wifi_mac": "AA:BB:CC:DD:EE:FF",
+                }
+            }
+        }
+
+        updated_air_purifier = await self.air_purifier_service.update(
+            self.test_air_purifier
+        )
+
+        self.assertTrue(updated_air_purifier.on)
+        self.assertTrue(updated_air_purifier.available)
+        self.assertEqual(updated_air_purifier.fan_mode, "auto")
+        self.assertEqual(updated_air_purifier.app_version, "1.0.18.0")
+        self.assertEqual(updated_air_purifier.sn, "SN123456789")
+        self.assertEqual(updated_air_purifier.wifi_mac, "AA:BB:CC:DD:EE:FF")
+
+    async def test_update_air_purifier_disconnected(self):
+        self.air_purifier_service._get_property_list.return_value = [
+            (PropertyIDs.ON, "1"),
+            (PropertyIDs.AVAILABLE, "1"),
+        ]
+        self.air_purifier_service._get_iot_prop.return_value = {
+            "data": {"props": {"iot_state": "disconnected"}}
+        }
+
+        updated_air_purifier = await self.air_purifier_service.update(
+            self.test_air_purifier
+        )
+
+        self.assertTrue(updated_air_purifier.on)
+        self.assertFalse(updated_air_purifier.available)
+
+    async def test_update_with_invalid_property(self):
+        self.air_purifier_service._get_property_list.return_value = []
+        self.air_purifier_service._get_iot_prop.return_value = {
+            "data": {
+                "props": {
+                    "invalid_property": "some_value",
+                    "fan_mode": "sleep",
+                }
+            }
+        }
+
+        updated_air_purifier = await self.air_purifier_service.update(
+            self.test_air_purifier
+        )
+
+        self.assertEqual(updated_air_purifier.fan_mode, "sleep")
+        self.assertFalse(updated_air_purifier.on)
+
+    async def test_update_air_quality(self):
+        self.air_purifier_service._get_air_prop.return_value = {
+            "data": {"settings": {"aqi": "6"}}
+        }
+
+        updated_air_purifier = await self.air_purifier_service.update_air_quality(
+            self.test_air_purifier
+        )
+
+        self.assertEqual(updated_air_purifier.aqi, 6)
+
+    async def test_update_air_quality_without_aqi(self):
+        self.air_purifier_service._get_air_prop.return_value = {
+            "data": {"settings": {}}
+        }
+        self.test_air_purifier.aqi = 6
+
+        updated_air_purifier = await self.air_purifier_service.update_air_quality(
+            self.test_air_purifier
+        )
+
+        self.assertIsNone(updated_air_purifier.aqi)
+
+    async def test_get_air_purifiers(self):
+        mock_air_purifier = MagicMock()
+        mock_air_purifier.type = DeviceTypes.COMMON
+        mock_air_purifier.product_model = "CO_AP1"
+        mock_air_purifier.raw_dict = {
+            "product_type": DeviceTypes.COMMON.value,
+            "product_model": "CO_AP1",
+            "mac": "AIRPURIFIER123",
+            "nickname": "Test Air Purifier",
+            "device_params": {"ip": "192.168.1.100"},
+        }
+
+        mock_other_device = MagicMock()
+        mock_other_device.type = DeviceTypes.COMMON
+        mock_other_device.product_model = "OTHER_MODEL"
+
+        self.air_purifier_service.get_object_list.return_value = [
+            mock_air_purifier,
+            mock_other_device,
+        ]
+
+        air_purifiers = await self.air_purifier_service.get_air_purifiers()
+
+        self.assertEqual(len(air_purifiers), 1)
+        self.assertIsInstance(air_purifiers[0], AirPurifier)
+        self.assertEqual(air_purifiers[0].product_model, "CO_AP1")
+        self.air_purifier_service.get_object_list.assert_awaited_once()
+
+    async def test_turn_on(self):
+        await self.air_purifier_service.turn_on(self.test_air_purifier)
+
+        self.air_purifier_service._set_property.assert_awaited_once_with(
+            self.test_air_purifier, PropertyIDs.ON.value, "1"
+        )
+
+    async def test_turn_off(self):
+        await self.air_purifier_service.turn_off(self.test_air_purifier)
+
+        self.air_purifier_service._set_property.assert_awaited_once_with(
+            self.test_air_purifier, PropertyIDs.ON.value, "0"
+        )
+
+    async def test_set_fan_mode_with_enum(self):
+        await self.air_purifier_service.set_fan_mode(
+            self.test_air_purifier, AirPurifierFanMode.TURBO
+        )
+
+        self.air_purifier_service._set_iot_prop.assert_awaited_once_with(
+            "https://wyze-earth-service.wyzecam.com/plugin/earth/set_iot_prop_by_topic",
+            self.test_air_purifier,
+            AirPurifierProps.FAN_MODE.value,
+            AirPurifierFanMode.TURBO.value,
+        )
+
+    async def test_set_fan_mode_with_string(self):
+        await self.air_purifier_service.set_fan_mode(self.test_air_purifier, "mid")
+
+        self.air_purifier_service._set_iot_prop.assert_awaited_once_with(
+            "https://wyze-earth-service.wyzecam.com/plugin/earth/set_iot_prop_by_topic",
+            self.test_air_purifier,
+            AirPurifierProps.FAN_MODE.value,
+            "mid",
+        )
+
+    async def test_air_purifier_get_iot_prop(self):
+        await self.air_purifier_service._air_purifier_get_iot_prop(
+            self.test_air_purifier
+        )
+
+        self.air_purifier_service._get_iot_prop.assert_awaited_once_with(
+            "https://wyze-earth-service.wyzecam.com/plugin/earth/get_iot_prop",
+            self.test_air_purifier,
+            "iot_state,fan_mode,app_version,sn,wifi_mac",
+        )
+
+    async def test_air_purifier_get_air_prop(self):
+        await self.air_purifier_service._air_purifier_get_air_prop(
+            self.test_air_purifier
+        )
+
+        self.air_purifier_service._get_air_prop.assert_awaited_once_with(
+            "https://wyze-earth-service.wyzecam.com/plugin/earth/get_air_prop",
+            self.test_air_purifier,
+            AirPurifierProps.AQI.value,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_air_purifier_service.py
+++ b/tests/test_air_purifier_service.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from wyzeapy.services.air_purifier_service import (
     AirPurifier,
@@ -19,6 +19,7 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
         self.air_purifier_service._get_iot_prop = AsyncMock()
         self.air_purifier_service._set_iot_prop = AsyncMock()
         self.air_purifier_service._get_air_prop = AsyncMock()
+        self.air_purifier_service._query_air_history = AsyncMock()
         self.air_purifier_service.get_object_list = AsyncMock()
 
         self.test_air_purifier = AirPurifier(
@@ -94,7 +95,11 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(updated_air_purifier.fan_mode, "sleep")
         self.assertFalse(updated_air_purifier.on)
 
-    async def test_update_air_quality(self):
+    @patch("wyzeapy.services.air_purifier_service.time.time", return_value=3700)
+    async def test_update_air_quality(self, _mock_time):
+        self.air_purifier_service._query_air_history.return_value = {
+            "data": [{"avg": -1, "max_aqi": 5}]
+        }
         self.air_purifier_service._get_air_prop.return_value = {
             "data": {"settings": {"aqi": "6"}}
         }
@@ -104,18 +109,78 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(updated_air_purifier.aqi, 6)
+        self.assertEqual(updated_air_purifier.max_hourly_aqi, 5)
+        self.assertEqual(updated_air_purifier.max_hourly_aqi_start_time, 3600)
+        self.assertEqual(updated_air_purifier.max_hourly_aqi_end_time, 3700)
+        self.air_purifier_service._get_air_prop.assert_awaited_once()
+        self.air_purifier_service._query_air_history.assert_awaited_once_with(
+            "https://wyze-earth-service.wyzecam.com/plugin/earth/query_air_history",
+            self.test_air_purifier,
+            3600,
+            3700,
+        )
+
+    async def test_update_air_quality_without_hourly_aqi(self):
+        self.air_purifier_service._query_air_history.return_value = {"data": []}
+        self.air_purifier_service._get_air_prop.return_value = {
+            "data": {"settings": {"aqi": "6"}}
+        }
+
+        updated_air_purifier = await self.air_purifier_service.update_air_quality(
+            self.test_air_purifier
+        )
+
+        self.assertEqual(updated_air_purifier.aqi, 6)
+        self.assertIsNone(updated_air_purifier.max_hourly_aqi)
 
     async def test_update_air_quality_without_aqi(self):
+        self.air_purifier_service._query_air_history.return_value = {"data": []}
         self.air_purifier_service._get_air_prop.return_value = {
             "data": {"settings": {}}
         }
         self.test_air_purifier.aqi = 6
+        self.test_air_purifier.max_hourly_aqi = 5
 
         updated_air_purifier = await self.air_purifier_service.update_air_quality(
             self.test_air_purifier
         )
 
         self.assertIsNone(updated_air_purifier.aqi)
+        self.assertIsNone(updated_air_purifier.max_hourly_aqi)
+
+    def test_air_quality_hour(self):
+        with patch(
+            "wyzeapy.services.air_purifier_service.time.time", return_value=3700
+        ):
+            begin_time, last_time = self.air_purifier_service._air_quality_hour()
+
+        self.assertEqual(begin_time, 3600)
+        self.assertEqual(last_time, 3700)
+
+    def test_get_max_hourly_aqi_uses_latest_max_aqi(self):
+        aqi = self.air_purifier_service._get_max_hourly_aqi(
+            [
+                {"avg": 1, "max_aqi": 0},
+                {"avg": -1, "max_aqi": 8},
+            ]
+        )
+
+        self.assertEqual(aqi, 8)
+
+    def test_get_max_hourly_aqi_returns_zero_when_sample_has_data(self):
+        aqi = self.air_purifier_service._get_max_hourly_aqi([{"avg": 0, "max_aqi": 0}])
+
+        self.assertEqual(aqi, 0)
+
+    def test_get_max_hourly_aqi_ignores_empty_sample(self):
+        aqi = self.air_purifier_service._get_max_hourly_aqi([{"avg": -1, "max_aqi": 0}])
+
+        self.assertIsNone(aqi)
+
+    def test_get_max_hourly_aqi_without_max_aqi(self):
+        aqi = self.air_purifier_service._get_max_hourly_aqi([{"avg": 4}])
+
+        self.assertIsNone(aqi)
 
     async def test_get_air_purifiers(self):
         mock_air_purifier = MagicMock()
@@ -201,6 +266,18 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
             "https://wyze-earth-service.wyzecam.com/plugin/earth/get_air_prop",
             self.test_air_purifier,
             AirPurifierProps.AQI.value,
+        )
+
+    async def test_air_purifier_query_air_history(self):
+        await self.air_purifier_service._air_purifier_query_air_history(
+            self.test_air_purifier, begin_time=1000, last_time=2000
+        )
+
+        self.air_purifier_service._query_air_history.assert_awaited_once_with(
+            "https://wyze-earth-service.wyzecam.com/plugin/earth/query_air_history",
+            self.test_air_purifier,
+            1000,
+            2000,
         )
 
 

--- a/tests/test_payload_factory.py
+++ b/tests/test_payload_factory.py
@@ -9,6 +9,7 @@ from wyzeapy.payload_factory import (
     olive_create_hms_patch_payload,
     devicemgmt_create_capabilities_payload,
     devicemgmt_get_iot_props_list,
+    olive_create_get_air_prop_payload,
 )
 from wyzeapy.crypto import olive_create_signature
 from unittest.mock import patch
@@ -43,6 +44,19 @@ class TestPayloadFactory(unittest.TestCase):
 
         self.assertEqual(result["keys"], keys)
         self.assertEqual(result["did"], device_mac)
+        self.assertEqual(result["nonce"], 1234567890123)
+
+    @patch("time.time", return_value=1234567890.123)
+    def test_olive_create_get_air_prop_payload(self, mock_time):
+        device_mac = "test_mac"
+        device_model = "CO_AP1"
+        prop_names = "aqi"
+
+        result = olive_create_get_air_prop_payload(device_mac, device_model, prop_names)
+
+        self.assertEqual(result["deviceId"], device_mac)
+        self.assertEqual(result["deviceModel"], device_model)
+        self.assertEqual(result["propNames"], prop_names)
         self.assertEqual(result["nonce"], 1234567890123)
 
     @patch("time.time", return_value=1234567890.123)

--- a/tests/test_payload_factory.py
+++ b/tests/test_payload_factory.py
@@ -10,6 +10,7 @@ from wyzeapy.payload_factory import (
     devicemgmt_create_capabilities_payload,
     devicemgmt_get_iot_props_list,
     olive_create_get_air_prop_payload,
+    olive_create_query_air_history_payload,
 )
 from wyzeapy.crypto import olive_create_signature
 from unittest.mock import patch
@@ -58,6 +59,13 @@ class TestPayloadFactory(unittest.TestCase):
         self.assertEqual(result["deviceModel"], device_model)
         self.assertEqual(result["propNames"], prop_names)
         self.assertEqual(result["nonce"], 1234567890123)
+
+    def test_olive_create_query_air_history_payload(self):
+        result = olive_create_query_air_history_payload("test_mac", 1000, 2000)
+
+        self.assertEqual(result["device_id"], "test_mac")
+        self.assertEqual(result["begin_time"], "1000")
+        self.assertEqual(result["last_time"], "2000")
 
     @patch("time.time", return_value=1234567890.123)
     def test_olive_create_post_payload(self, mock_time):

--- a/tests/test_wyzeapy.py
+++ b/tests/test_wyzeapy.py
@@ -227,6 +227,15 @@ async def test_thermostat_service(mock_auth_lib):
 
 
 @pytest.mark.asyncio
+async def test_air_purifier_service(mock_auth_lib):
+    wyze = await Wyzeapy.create()
+    await wyze.login("test@example.com", "password", "key_id", "api_key")
+    service = await wyze.air_purifier_service
+    assert service is not None
+    assert wyze._air_purifier_service is service
+
+
+@pytest.mark.asyncio
 async def test_hms_service(mock_auth_lib):
     wyze = await Wyzeapy.create()
     await wyze.login("test@example.com", "password", "key_id", "api_key")


### PR DESCRIPTION
## Summary
- add Wyze Air Purifier (`CO_AP1`) discovery and service support
- support power state, availability, fan mode control, and device metadata
- expose current AQI and current-hour max AQI from the Wyze air purifier endpoints
- add payload helper and service tests for purifier behavior

## Validation
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest -q` (`253 passed, 7 warnings`)
- live validated through ha-wyzeapi with two `CO_AP1` purifiers for several days

## Notes
- This intentionally does not bump the `wyzeapy` package version; release versioning is left to the maintainer release flow.