### PR TITLE
chore(release): cut 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ All notable changes to this project will be documented in this file.
 See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## 0.6.0 - 2026-06-07
+
+### Features
+
+* Add support for Wyze air purifiers (#262)
+* Add support for Wyze Cam Pan v4 (HL_PAN4) (#252)
+
+- - -
 ## 0.5.0..0.5.26 - 2023-12-08
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wyzeapy"
-version = "0.5.33"
+version = "0.6.0"
 description = "A library for interacting with Wyze devices"
 authors = [
     { name = "Katie Mulliken", email = "katie@mulliken.net" },

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "wyzeapy"
-version = "0.5.33"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## Summary
- Bump wyzeapy to 0.6.0
- Add changelog notes for Wyze air purifier and Wyze Cam Pan v4 support
- Refresh lockfile package version

## Validation
- uv sync --all-groups
- uv run ruff check .
- uv run --python 3.12 pytest tests/ -v
- uv build