### PR TITLE
Throttle air purifier AQI refreshes

### DIFF
--- a/src/wyzeapy/services/air_purifier_service.py
+++ b/src/wyzeapy/services/air_purifier_service.py
@@ -4,11 +4,13 @@ from enum import Enum
 from typing import Any, Dict, List
 
 from .base_service import BaseService
+from ..exceptions import UnknownApiError
 from ..types import AirPurifierProps, Device, DeviceTypes, PropertyIDs
 
 _LOGGER = logging.getLogger(__name__)
 
 AIR_PURIFIER_MODELS = {"CO_AP1"}
+AIR_QUALITY_UPDATE_INTERVAL = 20 * 60
 
 
 class AirPurifierFanMode(Enum):
@@ -31,6 +33,7 @@ class AirPurifier(Device):
         self.max_hourly_aqi: int | None = None
         self.max_hourly_aqi_start_time: int | None = None
         self.max_hourly_aqi_end_time: int | None = None
+        self.air_quality_updated_at: float | None = None
         self.app_version: str | None = None
         self.sn: str | None = None
         self.wifi_mac: str | None = None
@@ -70,6 +73,17 @@ class AirPurifierService(BaseService):
             elif prop == AirPurifierProps.WIFI_MAC:
                 air_purifier.wifi_mac = value
 
+        if self._should_update_air_quality(air_purifier):
+            try:
+                air_purifier = await self.update_air_quality(air_purifier)
+            except UnknownApiError as err:
+                air_purifier.air_quality_updated_at = time.time()
+                _LOGGER.warning(
+                    "Unable to update air quality for %s: %s",
+                    air_purifier.nickname,
+                    err,
+                )
+
         return air_purifier
 
     async def update_air_quality(self, air_purifier: AirPurifier) -> AirPurifier:
@@ -79,8 +93,20 @@ class AirPurifierService(BaseService):
         air_purifier.aqi = self._parse_int(aqi)
 
         await self._air_purifier_update_max_hourly_aqi(air_purifier)
+        air_purifier.air_quality_updated_at = time.time()
 
         return air_purifier
+
+    @staticmethod
+    def _should_update_air_quality(air_purifier: AirPurifier) -> bool:
+        if not air_purifier.available:
+            return False
+        if air_purifier.air_quality_updated_at is None:
+            return True
+        return (
+            time.time() - air_purifier.air_quality_updated_at
+            >= AIR_QUALITY_UPDATE_INTERVAL
+        )
 
     async def get_air_purifiers(self) -> List[AirPurifier]:
         if self._devices is None:

--- a/tests/test_air_purifier_service.py
+++ b/tests/test_air_purifier_service.py
@@ -1,7 +1,9 @@
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from wyzeapy.exceptions import UnknownApiError
 from wyzeapy.services.air_purifier_service import (
+    AIR_QUALITY_UPDATE_INTERVAL,
     AirPurifier,
     AirPurifierFanMode,
     AirPurifierService,
@@ -21,6 +23,10 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
         self.air_purifier_service._get_air_prop = AsyncMock()
         self.air_purifier_service._query_air_history = AsyncMock()
         self.air_purifier_service.get_object_list = AsyncMock()
+        self.air_purifier_service._get_air_prop.return_value = {
+            "data": {"settings": {}}
+        }
+        self.air_purifier_service._query_air_history.return_value = {"data": []}
 
         self.test_air_purifier = AirPurifier(
             {
@@ -60,6 +66,100 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(updated_air_purifier.app_version, "1.0.18.0")
         self.assertEqual(updated_air_purifier.sn, "SN123456789")
         self.assertEqual(updated_air_purifier.wifi_mac, "AA:BB:CC:DD:EE:FF")
+        self.air_purifier_service._get_air_prop.assert_awaited_once()
+        self.air_purifier_service._query_air_history.assert_awaited_once()
+
+    @patch("wyzeapy.services.air_purifier_service.time.time", return_value=3700)
+    async def test_update_keeps_device_state_when_air_quality_fails(self, _mock_time):
+        self.air_purifier_service._get_property_list.return_value = [
+            (PropertyIDs.ON, "1"),
+            (PropertyIDs.AVAILABLE, "1"),
+        ]
+        self.air_purifier_service._get_iot_prop.return_value = {
+            "data": {"props": {"iot_state": "connected", "fan_mode": "auto"}}
+        }
+        self.air_purifier_service._get_air_prop.side_effect = UnknownApiError(
+            {"code": 5030}
+        )
+
+        updated_air_purifier = await self.air_purifier_service.update(
+            self.test_air_purifier
+        )
+
+        self.assertTrue(updated_air_purifier.on)
+        self.assertTrue(updated_air_purifier.available)
+        self.assertEqual(updated_air_purifier.fan_mode, "auto")
+        self.assertIsNone(updated_air_purifier.aqi)
+        self.assertEqual(updated_air_purifier.air_quality_updated_at, 3700)
+        self.air_purifier_service._get_air_prop.assert_awaited_once()
+        self.air_purifier_service._query_air_history.assert_not_awaited()
+
+    @patch("wyzeapy.services.air_purifier_service.time.time", return_value=3700)
+    async def test_update_refreshes_air_quality_when_stale(self, _mock_time):
+        self.air_purifier_service._get_property_list.return_value = []
+        self.air_purifier_service._get_iot_prop.return_value = {
+            "data": {"props": {"iot_state": "connected"}}
+        }
+        self.air_purifier_service._query_air_history.return_value = {
+            "data": [{"avg": -1, "max_aqi": 5}]
+        }
+        self.air_purifier_service._get_air_prop.return_value = {
+            "data": {"settings": {"aqi": "6"}}
+        }
+
+        updated_air_purifier = await self.air_purifier_service.update(
+            self.test_air_purifier
+        )
+
+        self.assertEqual(updated_air_purifier.aqi, 6)
+        self.assertEqual(updated_air_purifier.max_hourly_aqi, 5)
+        self.assertEqual(updated_air_purifier.air_quality_updated_at, 3700)
+        self.air_purifier_service._get_air_prop.assert_awaited_once()
+        self.air_purifier_service._query_air_history.assert_awaited_once()
+
+    @patch("wyzeapy.services.air_purifier_service.time.time")
+    async def test_update_uses_cached_air_quality_before_interval(self, mock_time):
+        mock_time.return_value = AIR_QUALITY_UPDATE_INTERVAL
+        self.air_purifier_service._get_property_list.return_value = []
+        self.air_purifier_service._get_iot_prop.return_value = {
+            "data": {"props": {"iot_state": "connected"}}
+        }
+        self.test_air_purifier.air_quality_updated_at = 1
+        self.test_air_purifier.aqi = 6
+        self.test_air_purifier.max_hourly_aqi = 5
+
+        updated_air_purifier = await self.air_purifier_service.update(
+            self.test_air_purifier
+        )
+
+        self.assertEqual(updated_air_purifier.aqi, 6)
+        self.assertEqual(updated_air_purifier.max_hourly_aqi, 5)
+        self.air_purifier_service._get_air_prop.assert_not_awaited()
+        self.air_purifier_service._query_air_history.assert_not_awaited()
+
+    @patch("wyzeapy.services.air_purifier_service.time.time")
+    async def test_update_refreshes_air_quality_after_interval(self, mock_time):
+        mock_time.return_value = AIR_QUALITY_UPDATE_INTERVAL + 1
+        self.air_purifier_service._get_property_list.return_value = []
+        self.air_purifier_service._get_iot_prop.return_value = {
+            "data": {"props": {"iot_state": "connected"}}
+        }
+        self.test_air_purifier.air_quality_updated_at = 1
+        self.air_purifier_service._query_air_history.return_value = {
+            "data": [{"avg": -1, "max_aqi": 5}]
+        }
+        self.air_purifier_service._get_air_prop.return_value = {
+            "data": {"settings": {"aqi": "6"}}
+        }
+
+        updated_air_purifier = await self.air_purifier_service.update(
+            self.test_air_purifier
+        )
+
+        self.assertEqual(updated_air_purifier.aqi, 6)
+        self.assertEqual(updated_air_purifier.max_hourly_aqi, 5)
+        self.air_purifier_service._get_air_prop.assert_awaited_once()
+        self.air_purifier_service._query_air_history.assert_awaited_once()
 
     async def test_update_air_purifier_disconnected(self):
         self.air_purifier_service._get_property_list.return_value = [
@@ -76,6 +176,8 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(updated_air_purifier.on)
         self.assertFalse(updated_air_purifier.available)
+        self.air_purifier_service._get_air_prop.assert_not_awaited()
+        self.air_purifier_service._query_air_history.assert_not_awaited()
 
     async def test_update_with_invalid_property(self):
         self.air_purifier_service._get_property_list.return_value = []
@@ -112,6 +214,7 @@ class TestAirPurifierService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(updated_air_purifier.max_hourly_aqi, 5)
         self.assertEqual(updated_air_purifier.max_hourly_aqi_start_time, 3600)
         self.assertEqual(updated_air_purifier.max_hourly_aqi_end_time, 3700)
+        self.assertEqual(updated_air_purifier.air_quality_updated_at, 3700)
         self.air_purifier_service._get_air_prop.assert_awaited_once()
         self.air_purifier_service._query_air_history.assert_awaited_once_with(
             "https://wyze-earth-service.wyzecam.com/plugin/earth/query_air_history",


### PR DESCRIPTION
## Summary
- Populate air purifier current AQI and current-hour max AQI during `AirPurifierService.update()` so callers using the existing device update callbacks receive air quality with normal device state.
- Throttle the dedicated air quality endpoints to one refresh per purifier every 20 minutes, reusing cached AQI values between normal device updates.
- Skip AQI endpoint calls while a purifier is unavailable.
- Keep fan/device state updates working if the AQI endpoint returns an unknown API error, and delay the next AQI retry.
- Add service tests for refresh timing, cached values, unavailable devices, and AQI endpoint failure handling.

## Home Assistant integration flow
The HA integration registers the purifier with the existing `wyzeapy` update manager from the fan entity, then sibling AQI sensors listen for the device update callback. This keeps the dedicated `get_air_prop` and `query_air_history` calls centralized in `wyzeapy` instead of adding a separate Home Assistant refresh task for the AQI sensors.

## Validation
- `uv run python -m unittest tests.test_air_purifier_service -v`
- `uv run python -m unittest discover tests -v` (`203` tests)
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`