### PR TITLE
fix(bulb): turn WLPA19 (DeviceTypes.LIGHT) bulbs on/off via bulk device_list endpoint

### DIFF
--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -352,6 +352,47 @@ class BaseService:
 
         check_for_errors_standard(self, response_json)
 
+    async def _set_device_list_property_list(
+        self, device: Device, plist: List[Dict[str, str]]
+    ):
+        """Wraps the api.wyzecam.com/app/v2/device_list/set_property_list (bulk) endpoint.
+
+        Current bulb firmware (e.g. WLPA19) silently ignores the P3 power property sent to
+        the single-device ``device/set_property_list`` endpoint (the server returns
+        ``code 1 / SUCCESS`` but the bulb no-ops). The Wyze app drives power through this
+        bulk ``device_list`` endpoint, which the firmware honors. Verified on-device
+        against real ``get_property_list`` reads, both directions.
+
+        :param device: The device for which to set the property(ies)
+        :param plist: A list of properties [{"pid": pid, "pvalue": pvalue},...]
+        """
+        await self._auth_lib.refresh_if_should()
+
+        payload = {
+            "phone_system_type": PHONE_SYSTEM_TYPE,
+            "app_version": APP_VERSION,
+            "app_ver": APP_VER,
+            "sc": "a626948714654991afd3c0dbd7cdb901",
+            "ts": int(time.time()),
+            "sv": "ddb9baef0d7f44379cd6bfaa8698e682",
+            "access_token": self._auth_lib.token.access_token,
+            "phone_id": PHONE_ID,
+            "app_name": APP_NAME,
+            "device_list": [
+                {
+                    "device_mac": device.mac,
+                    "device_model": device.product_model,
+                    "property_list": plist,
+                }
+            ],
+        }
+
+        response_json = await self._auth_lib.post(
+            "https://api.wyzecam.com/app/v2/device_list/set_property_list", json=payload
+        )
+
+        check_for_errors_standard(self, response_json)
+
     async def _run_action_list(self, device: Device, plist: List[Dict[Any, Any]]):
         """Wraps the api.wyzecam.com/app/v2/auto/run_action_list endpoint
 

--- a/src/wyzeapy/services/bulb_service.py
+++ b/src/wyzeapy/services/bulb_service.py
@@ -173,7 +173,9 @@ class BulbService(BaseService):
             plist.extend(options)
 
         if bulb.type is DeviceTypes.LIGHT:
-            await self._set_property_list(bulb, plist)
+            # Power (P3) is only honored via the bulk device_list endpoint on
+            # current bulb firmware; the single-device endpoint no-ops it.
+            await self._set_device_list_property_list(bulb, plist)
 
         elif bulb.type in [DeviceTypes.MESH_LIGHT, DeviceTypes.LIGHTSTRIP]:
             # Local Control
@@ -196,7 +198,9 @@ class BulbService(BaseService):
         plist = [create_pid_pair(PropertyIDs.ON, "0")]
 
         if bulb.type in [DeviceTypes.LIGHT]:
-            await self._set_property_list(bulb, plist)
+            # Power (P3) is only honored via the bulk device_list endpoint on
+            # current bulb firmware; the single-device endpoint no-ops it.
+            await self._set_device_list_property_list(bulb, plist)
         elif bulb.type in [DeviceTypes.MESH_LIGHT, DeviceTypes.LIGHTSTRIP]:
             if local_control and not bulb.cloud_fallback:
                 await self._local_bulb_command(bulb, plist)


### PR DESCRIPTION
## Problem

On current Wyze bulb firmware, `turn_on` / `turn_off` for a Wyze Bulb (model **WLPA19**, `DeviceTypes.LIGHT`) have no physical effect, while brightness and color temperature work normally. The bulb's `P3` power write returns `code 1 / SUCCESS` but the bulb ignores it.

This surfaced downstream as ha-wyzeapi issue SecKatie/ha-wyzeapi#867 (HA `light.turn_on`/`light.turn_off` do nothing for these bulbs).

## Root cause

`BulbService.turn_on` / `turn_off` send `P3` to the **single-device** endpoint:

```
POST /app/v2/device/set_property_list
  { device_mac, device_model, property_list: [{pid: "P3", pvalue: "0"}], ... }
```

Current firmware no-ops `P3` on that endpoint. The official Wyze app drives bulb power through a **bulk** endpoint instead:

```
POST /app/v2/device_list/set_property_list      (sv ddb9baef0d7f44379cd6bfaa8698e682)
  { device_list: [ { device_mac, device_model, property_list: [{pid: "P3", pvalue: "0"}] } ], ... }
```

Same API host and token auth — just a newer endpoint with a `device_list[]` wrapper. (Captured from the Wyze Android app and confirmed in the decompiled APK.)

## Change

- Add `BaseService._set_device_list_property_list(device, plist)` wrapping the bulk `device_list/set_property_list` endpoint.
- Route the `DeviceTypes.LIGHT` power branch of `turn_on` / `turn_off` through it. `MESH_LIGHT` / `LIGHTSTRIP` paths and brightness / color are unchanged.

## Verification

Tested on a real WLPA19, reading `P3` from `get_property_list` (actual device state, not the optimistic in-memory flag) before/after each call:

```
turn_off -> SUCCESS -> get_property_list P3 = 0   (bulb physically off)
turn_on  -> SUCCESS -> get_property_list P3 = 1   (bulb physically on)
```

Repeatable both directions, and confirmed end-to-end through Home Assistant `light.turn_off` / `light.turn_on`.

`ruff check` and `ruff format` pass on the changed files.
