### PR TITLE
fix(tls): preserve system CA certificates

### DIFF
--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -45,8 +45,9 @@ _EXTRA_CA_BUNDLE = Path(__file__).with_name("wyze_api_ca.pem")
 
 @cache
 def get_ssl_context() -> ssl.SSLContext:
-    """Return an SSL context containing certifi and Wyze's legacy root CA."""
-    context = ssl.create_default_context(cafile=certifi.where())
+    """Return an SSL context containing system, certifi, and Wyze CA roots."""
+    context = ssl.create_default_context()
+    context.load_verify_locations(cafile=certifi.where())
     context.load_verify_locations(cafile=_EXTRA_CA_BUNDLE)
     return context
 

--- a/tests/test_wyze_auth_lib.py
+++ b/tests/test_wyze_auth_lib.py
@@ -1,4 +1,5 @@
 from hashlib import sha256
+import ssl
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
 from wyzeapy.wyze_auth_lib import (
@@ -14,11 +15,18 @@ import aiohttp  # Import aiohttp
 
 
 class TestWyzeAuthLib(unittest.IsolatedAsyncioTestCase):
-    def test_ssl_context_includes_certifi_and_wyze_ca(self):
+    def test_ssl_context_includes_system_certifi_and_wyze_ca(self):
         certificates = get_ssl_context().get_ca_certs(binary_form=True)
         fingerprints = {sha256(certificate).hexdigest() for certificate in certificates}
+        system_certificates = ssl.create_default_context().get_ca_certs(
+            binary_form=True
+        )
+        system_fingerprints = {
+            sha256(certificate).hexdigest() for certificate in system_certificates
+        }
 
         self.assertGreater(len(certificates), 1)
+        self.assertLessEqual(system_fingerprints, fingerprints)
         self.assertIn(
             "4348a0e9444c78cb265e058d5e8944b4d84f9662bd26db257f8934a443c70161",
             fingerprints,


### PR DESCRIPTION
## Summary

- create the Wyze TLS context from Python's platform trust store
- augment that context with Certifi and the packaged Wyze legacy root
- verify that every available system CA remains trusted

## Why

The TLS fix in #288 starts from `certifi.where()`, which replaces the platform trust store. Environments that install enterprise, proxy, or private CA certificates into the system store can therefore lose trust after upgrading.

Starting from `ssl.create_default_context()` preserves those environment-specific roots. Loading Certifi and `wyze_api_ca.pem` afterward retains the original fix for Wyze's legacy DigiCert chain.

## Impact

Existing system CA customizations continue to work when available, while standard Certifi roots and the packaged Wyze root remain trusted.

## Validation

- `uv run ruff check .`
- `uv run pytest -q tests/test_wyze_auth_lib.py` — 29 passed
- `uv run pytest -q` — 258 passed