### PR TITLE
fix(tls): route /app API through app.wyzecam.com (G2 root)

### DIFF
--- a/src/wyzeapy/const.py
+++ b/src/wyzeapy/const.py
@@ -12,6 +12,11 @@ Configuration constants for Wyze API integration, including app metadata,
 API keys, and cryptographic secrets.
 """
 PHONE_SYSTEM_TYPE = "1"
+# Base host for the primary Wyze "/app" API. Points at app.wyzecam.com, whose cert
+# chains to DigiCert Global Root G2 (trusted by current certifi bundles). The former
+# host, api.wyzecam.com, still chains to the distrusted DigiCert Global Root CA (G1),
+# which certifi removed in 2026.06.17. See ha-wyzeapi issue #876.
+WYZE_API_URL = "https://app.wyzecam.com"
 API_KEY = "WMXHYf79Nr5gIlt3r0r7p9Tcw5bvs6BB4U8O8nGJ"
 APP_VERSION = "2.18.43"
 APP_VER = "com.hualai.WyzeCam___2.18.43"

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -13,6 +13,7 @@ import aiohttp
 
 from .update_manager import DeviceUpdater, UpdateManager
 from ..const import (
+    WYZE_API_URL,
     PHONE_SYSTEM_TYPE,
     APP_VERSION,
     APP_VER,
@@ -176,7 +177,7 @@ class BaseService:
         """
         await self._auth_lib.refresh_if_should()
 
-        url = "https://api.wyzecam.com/app/user/set_push_info"
+        url = f"{WYZE_API_URL}/app/user/set_push_info"
         payload = {
             "phone_system_type": PHONE_SYSTEM_TYPE,
             "app_version": APP_VERSION,
@@ -254,7 +255,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/home_page/get_object_list", json=payload
+            f"{WYZE_API_URL}/app/v2/home_page/get_object_list", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -307,7 +308,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/device/get_property_list", json=payload
+            f"{WYZE_API_URL}/app/v2/device/get_property_list", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -347,7 +348,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/device/set_property_list", json=payload
+            f"{WYZE_API_URL}/app/v2/device/set_property_list", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -388,7 +389,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/device_list/set_property_list", json=payload
+            f"{WYZE_API_URL}/app/v2/device_list/set_property_list", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -422,7 +423,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/auto/run_action_list", json=payload
+            f"{WYZE_API_URL}/app/v2/auto/run_action_list", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -458,7 +459,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/device/get_event_list", json=payload
+            f"{WYZE_API_URL}/app/v2/device/get_event_list", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -491,7 +492,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/auto/run_action", json=payload
+            f"{WYZE_API_URL}/app/v2/auto/run_action", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -637,7 +638,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/device/set_property", json=payload
+            f"{WYZE_API_URL}/app/v2/device/set_property", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -820,7 +821,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/device/get_device_Info", json=payload
+            f"{WYZE_API_URL}/app/v2/device/get_device_Info", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -989,7 +990,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://api.wyzecam.com/app/v2/plug/usage_record_list", json=payload
+            f"{WYZE_API_URL}/app/v2/plug/usage_record_list", json=payload
         )
 
         check_for_errors_standard(self, response_json)
@@ -1132,7 +1133,7 @@ class BaseService:
         }
 
         response_json = await self._auth_lib.post(
-            "https://app.wyzecam.com/app/v4/camera/get-streams",
+            f"{WYZE_API_URL}/app/v4/camera/get-streams",
             json=payload,
             headers=headers,
         )

--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -15,6 +15,7 @@ import certifi
 from aiohttp import TCPConnector, ClientSession, ContentTypeError
 
 from .const import (
+    WYZE_API_URL,
     API_KEY,
     PHONE_ID,
     APP_NAME,
@@ -351,7 +352,7 @@ class WyzeAuthLib:
 
         async with _create_client_session() as _session:
             response = await _session.post(
-                "https://api.wyzecam.com/app/user/refresh_token",
+                f"{WYZE_API_URL}/app/user/refresh_token",
                 headers=headers,
                 json=payload,
             )


### PR DESCRIPTION
## Summary

`api.wyzecam.com` serves a certificate chained to the distrusted **DigiCert Global Root CA (G1)**, which `certifi` removed in **2026.06.17**, breaking TLS verification for the primary `/app` API on newer trust stores (e.g. recent Home Assistant environments). This routes the `/app` API through **`app.wyzecam.com`**, which serves the *identical* `/app` API behind a certificate chained to **DigiCert Global Root G2** (still trusted by current certifi bundles).

Refs: #876

## Why this is a temporary, client-side workaround

`api.wyzecam.com` is one of Wyze's oldest domains and historically serves two different purposes:

* **Firmware communication** between Wyze devices and the Wyze Cloud.
* **Legacy APIs** used by the mobile app, web app, and unofficial integrations such as Home Assistant and Homebridge.

Because `api.wyzecam.com` is also used for firmware communication, the certificate chain can't simply be switched to DigiCert G2/G5 server-side without carefully evaluating the impact on deployed devices — doing so could break connectivity for existing firmware. Until that server-side migration is evaluated, moving the client to the already-G2 `app.wyzecam.com` front is the safe fix.

## Changes

* Add a `WYZE_API_URL` constant (`https://app.wyzecam.com`) in `const.py`.
* Route all `/app/...` calls through it — `base_service.py` (object list, properties, actions, events, device info, plug usage, push info, camera streams) and `refresh_token` in `wyze_auth_lib.py`.

`app.wyzecam.com` was already used for `/app/v4/camera/get-streams`, and returns byte-identical responses to `api.wyzecam.com` for the migrated endpoints.

## Scope — what this does and doesn't fix

Tested every host the library uses against a clean `certifi 2026.06.17` bundle (no bundled root, no OS store):

| Host | Used for | Result |
|------|----------|--------|
| `api.wyzecam.com` → **`app.wyzecam.com`** | core `/app` API | ❌→ ✅ (this PR) |
| `wyze-earth-service.wyzecam.com` | thermostat / air purifier | ❌ still G1 |
| `yd-saas-toc.wyzecam.com` | locks | ❌ still G1 |
| `auth-prod.api.wyze.com` | login / 2FA | ✅ already G2 |
| `hms.api.wyze.com` | HMS | ✅ already G2 |
| `wyze-platform-service.wyzecam.com` | user profile | ✅ already G2 |
| `wyze-membership-service.wyzecam.com` | plans | ✅ already G2 |
| `wyze-sirius-service.wyzecam.com` | wall switch | ✅ already G2 |
| `wyze-lockwood-service.wyzecam.com` | irrigation | ✅ already G2 |
| `devicemgmt-service-beta.wyze.com` | new-API devices | ✅ Amazon root |

The packaged legacy G1 root (`wyze_api_ca.pem`) is **still required** for `wyze-earth-service` and `yd-saas-toc`, which remain on the G1 chain and resolve directly to AWS ELBs (no G2/CDN front available). This PR does not remove it.

## Testing

* `uv run pytest tests/` → **229 passed**
* `uv run ruff check src/` and `ruff format --check src/` → clean