### PR TITLE
feat(irrigation): add typed runtime data APIs

### DIFF
--- a/src/wyzeapy/payload_factory.py
+++ b/src/wyzeapy/payload_factory.py
@@ -81,6 +81,15 @@ def olive_create_get_payload_irrigation(device_mac: str) -> Dict[str, Any]:
     return {"device_id": device_mac, "nonce": str(nonce)}
 
 
+def olive_create_get_payload_irrigation_device_info(
+    device_mac: str, keys: str
+) -> Dict[str, Any]:
+    """Build a sprinkler device-info request payload."""
+    payload = olive_create_get_payload_irrigation(device_mac)
+    payload["keys"] = keys
+    return payload
+
+
 def olive_create_post_payload_irrigation_stop(
     device_mac: str, action: str
 ) -> Dict[str, Any]:

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -41,6 +41,7 @@ from ..payload_factory import (
     devicemgmt_create_capabilities_payload,
     devicemgmt_get_iot_props_list,
     olive_create_get_payload_irrigation,
+    olive_create_get_payload_irrigation_device_info,
     olive_create_post_payload_irrigation_stop,
     olive_create_post_payload_irrigation_quickrun,
     olive_create_get_payload_irrigation_schedule_runs,
@@ -1000,6 +1001,30 @@ class BaseService:
         await self._auth_lib.refresh_if_should()
 
         payload = olive_create_get_payload_irrigation(device.mac)
+        signature = olive_create_signature(payload, self._auth_lib.token.access_token)
+        headers = {
+            "Accept-Encoding": "gzip",
+            "User-Agent": "myapp",
+            "appid": OLIVE_APP_ID,
+            "appinfo": APP_INFO,
+            "phoneid": PHONE_ID,
+            "access_token": self._auth_lib.token.access_token,
+            "signature2": signature,
+        }
+
+        response_json = await self._auth_lib.get(url, headers=headers, params=payload)
+
+        check_for_errors_iot(self, response_json)
+
+        return response_json
+
+    async def _irrigation_device_info(
+        self, url: str, device: Device, keys: str
+    ) -> Dict[Any, Any]:
+        """Fetch selected sprinkler controller properties."""
+        await self._auth_lib.refresh_if_should()
+
+        payload = olive_create_get_payload_irrigation_device_info(device.mac, keys)
         signature = olive_create_signature(payload, self._auth_lib.token.access_token)
         headers = {
             "Accept-Encoding": "gzip",

--- a/src/wyzeapy/services/irrigation_service.py
+++ b/src/wyzeapy/services/irrigation_service.py
@@ -1,11 +1,186 @@
 import logging
+from dataclasses import dataclass, field
 from enum import Enum
+import json
+from time import time
 from typing import Any, Dict, List
 
 from .base_service import BaseService
 from ..types import Device, IrrigationProps, DeviceTypes
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class IrrigationRun:
+    """A currently active sprinkler zone run."""
+
+    zone_number: int
+    zone_name: str | None
+    start_ts: int | None
+    end_ts: int | None
+    schedule_name: str | None
+    schedule_type: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class IrrigationControllerInfo:
+    """Configuration and diagnostic properties for a sprinkler controller."""
+
+    schedules_enabled: bool | None
+    wiring: Any = None
+    sensor: Any = None
+    notification_enabled: Any = None
+    notification_watering_begins: Any = None
+    notification_watering_ends: Any = None
+    notification_watering_is_skipped: Any = None
+    skip_low_temp: Any = None
+    skip_wind: Any = None
+    skip_rain: Any = None
+    skip_saturation: Any = None
+    raw_dict: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+def _timestamp(value: Any) -> int | None:
+    """Return a valid Unix timestamp from an API value."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _integer(value: Any) -> int | None:
+    """Return a valid integer from an API value."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _boolean(value: Any) -> bool | None:
+    """Return a normalized boolean from an API value."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.casefold()
+        if normalized in {"1", "true", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "off", "disabled"}:
+            return False
+    return None
+
+
+def _find_property(value: Any, name: str) -> Any:
+    """Find a named property in nested Wyze response formats."""
+    if isinstance(value, dict):
+        if name in value:
+            return value[name]
+
+        property_name = value.get("key", value.get("name"))
+        if property_name == name and "value" in value:
+            return value["value"]
+
+        for nested_value in value.values():
+            result = _find_property(nested_value, name)
+            if result is not None:
+                return result
+        return None
+
+    if isinstance(value, list):
+        for nested_value in value:
+            result = _find_property(nested_value, name)
+            if result is not None:
+                return result
+        return None
+
+    if isinstance(value, str) and value.lstrip().startswith(("{", "[")):
+        try:
+            return _find_property(json.loads(value), name)
+        except json.JSONDecodeError:
+            return None
+
+    return None
+
+
+def _parse_current_run(
+    response: Dict[Any, Any], now_timestamp: int | None = None
+) -> IrrigationRun | None:
+    """Parse the active zone whose time interval contains the current time."""
+    now_timestamp = int(time()) if now_timestamp is None else now_timestamp
+    schedules = response.get("data", {}).get("schedules", [])
+
+    for schedule in schedules:
+        if schedule.get("schedule_state") != "running":
+            continue
+
+        zone_runs = schedule.get("zone_runs") or []
+        if not zone_runs:
+            return None
+
+        current_run = next(
+            (
+                zone_run
+                for zone_run in zone_runs
+                if (start := _timestamp(zone_run.get("start_ts"))) is not None
+                and start <= now_timestamp
+                and (
+                    (end := _timestamp(zone_run.get("end_ts"))) is None
+                    or now_timestamp < end
+                )
+            ),
+            None,
+        )
+        if current_run is None and len(zone_runs) == 1:
+            only_run = zone_runs[0]
+            if (
+                _timestamp(only_run.get("start_ts")) is None
+                and _timestamp(only_run.get("end_ts")) is None
+            ):
+                current_run = only_run
+        if current_run is None:
+            return None
+
+        zone_number = _integer(current_run.get("zone_number"))
+        if zone_number is None:
+            return None
+
+        return IrrigationRun(
+            zone_number=zone_number,
+            zone_name=current_run.get("zone_name"),
+            start_ts=_timestamp(current_run.get("start_ts")),
+            end_ts=_timestamp(current_run.get("end_ts")),
+            schedule_name=schedule.get("schedule_name"),
+            schedule_type=current_run.get(
+                "schedule_type", schedule.get("schedule_type")
+            ),
+        )
+
+    return None
+
+
+def _parse_controller_info(response: Dict[Any, Any]) -> IrrigationControllerInfo:
+    """Parse controller properties while retaining the raw API data."""
+    data = response.get("data", {})
+    return IrrigationControllerInfo(
+        schedules_enabled=_boolean(_find_property(data, "enable_schedules")),
+        wiring=_find_property(data, "wiring"),
+        sensor=_find_property(data, "sensor"),
+        notification_enabled=_find_property(data, "notification_enable"),
+        notification_watering_begins=_find_property(
+            data, "notification_watering_begins"
+        ),
+        notification_watering_ends=_find_property(data, "notification_watering_ends"),
+        notification_watering_is_skipped=_find_property(
+            data, "notification_watering_is_skipped"
+        ),
+        skip_low_temp=_find_property(data, "skip_low_temp"),
+        skip_wind=_find_property(data, "skip_wind"),
+        skip_rain=_find_property(data, "skip_rain"),
+        skip_saturation=_find_property(data, "skip_saturation"),
+        raw_dict=data if isinstance(data, dict) else {"value": data},
+    )
 
 
 class CropType(Enum):
@@ -193,7 +368,7 @@ class IrrigationService(BaseService):
         return await self._get_iot_prop(url, device, keys)
 
     async def get_device_info(self, device: Device) -> Dict[Any, Any]:
-        """Get device info from Wyze API."""
+        """Get the raw device-info response from the Wyze API."""
         url = "https://wyze-lockwood-service.wyzecam.com/plugin/irrigation/device_info"
         keys = (
             "wiring,sensor,enable_schedules,notification_enable,notification_watering_begins,"
@@ -201,6 +376,10 @@ class IrrigationService(BaseService):
             "skip_rain,skip_saturation"
         )
         return await self._irrigation_device_info(url, device, keys)
+
+    async def get_controller_info(self, device: Device) -> IrrigationControllerInfo:
+        """Get normalized sprinkler controller configuration."""
+        return _parse_controller_info(await self.get_device_info(device))
 
     async def get_zone_by_device(self, device: Device) -> List[Dict[Any, Any]]:
         """Get zones for a device."""
@@ -220,27 +399,33 @@ class IrrigationService(BaseService):
             "https://wyze-lockwood-service.wyzecam.com/plugin/irrigation/schedule_runs"
         )
         response = await self._get_schedule_runs(url, device, limit=2)
-
-        # Process the response and return simplified payload
-        result = {"running": False}
-
-        if "data" in response and "schedules" in response["data"]:
-            schedules = response["data"]["schedules"]
-            for schedule in schedules:
-                schedule_state = schedule.get("schedule_state")
-
-                if schedule_state == "running":
-                    result["running"] = True
-                    # Get zone information from zone_runs
-                    zone_runs = schedule.get("zone_runs")
-                    # Use the first zone run for zone info
-                    zone_run = zone_runs[0]
-                    result["zone_number"] = zone_run.get("zone_number")
-                    result["zone_name"] = zone_run.get("zone_name")
-                    break  # Found a running schedule, no need to check others
-        else:
+        if "data" not in response or "schedules" not in response["data"]:
             _LOGGER.warning(
                 "No schedule data found in response for device %s", device.mac
             )
+            return {"running": False}
 
-        return result
+        for schedule in response["data"]["schedules"]:
+            if schedule.get("schedule_state") != "running":
+                continue
+            zone_runs = schedule.get("zone_runs") or []
+            if not zone_runs:
+                return {"running": True}
+            zone_run = zone_runs[0]
+            return {
+                "running": True,
+                "zone_number": zone_run.get("zone_number"),
+                "zone_name": zone_run.get("zone_name"),
+            }
+
+        return {"running": False}
+
+    async def get_current_run(
+        self, device: Device, *, now_timestamp: int | None = None
+    ) -> IrrigationRun | None:
+        """Get the zone that is currently watering, including timer metadata."""
+        url = (
+            "https://wyze-lockwood-service.wyzecam.com/plugin/irrigation/schedule_runs"
+        )
+        response = await self._get_schedule_runs(url, device, limit=2)
+        return _parse_current_run(response, now_timestamp)

--- a/tests/test_irrigation_service.py
+++ b/tests/test_irrigation_service.py
@@ -1,6 +1,12 @@
 import unittest
 from unittest.mock import AsyncMock, MagicMock
-from wyzeapy.services.irrigation_service import IrrigationService, Irrigation, Zone
+from wyzeapy.services.irrigation_service import (
+    Irrigation,
+    IrrigationControllerInfo,
+    IrrigationRun,
+    IrrigationService,
+    Zone,
+)
 from wyzeapy.types import DeviceTypes, Device
 from wyzeapy.wyze_auth_lib import WyzeAuthLib
 
@@ -290,6 +296,54 @@ class TestIrrigationService(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result, expected_response)
 
+    async def test_get_device_info_uses_irrigation_payload(self):
+        """Device info sends the endpoint's required device_id and keys."""
+        auth_lib = MagicMock(spec=WyzeAuthLib)
+        auth_lib.refresh_if_should = AsyncMock()
+        auth_lib.get = AsyncMock(
+            return_value={
+                "code": 1,
+                "data": {"props": {"enable_schedules": True}},
+            }
+        )
+        auth_lib.token = MagicMock(access_token="token")
+        service = IrrigationService(auth_lib=auth_lib)
+
+        result = await service.get_device_info(self.test_irrigation)
+
+        self.assertTrue(result["data"]["props"]["enable_schedules"])
+        auth_lib.refresh_if_should.assert_awaited_once()
+        request = auth_lib.get.await_args
+        self.assertEqual(
+            request.args[0],
+            "https://wyze-lockwood-service.wyzecam.com/plugin/irrigation/device_info",
+        )
+        self.assertEqual(request.kwargs["params"]["device_id"], "IRRIG123")
+        self.assertIn("enable_schedules", request.kwargs["params"]["keys"])
+        self.assertNotIn("did", request.kwargs["params"])
+
+    async def test_get_controller_info(self):
+        """Controller info normalizes nested Wyze property formats."""
+        self.irrigation_service.get_device_info = AsyncMock(
+            return_value={
+                "data": {
+                    "props": (
+                        '{"properties": ['
+                        '{"key": "enable_schedules", "value": "enabled"}, '
+                        '{"key": "wiring", "value": {"1": true}}'
+                        "]}"
+                    )
+                }
+            }
+        )
+
+        result = await self.irrigation_service.get_controller_info(self.test_irrigation)
+
+        self.assertIsInstance(result, IrrigationControllerInfo)
+        self.assertTrue(result.schedules_enabled)
+        self.assertEqual(result.wiring, {"1": True})
+        self.assertIn("props", result.raw_dict)
+
     async def test_get_zone_by_device_method(self):
         # Mock the get_zone_by_device method directly to test the public interface
         expected_response = {"data": {"zones": [{"zone_number": 1, "name": "Zone 1"}]}}
@@ -572,6 +626,115 @@ class TestIrrigationServiceEdgeCases(unittest.IsolatedAsyncioTestCase):
         # Verify the result
         expected_result = {"running": True, "zone_number": 3, "zone_name": "Backyard S"}
         self.assertEqual(result, expected_result)
+
+    async def test_get_current_run_selects_active_sequential_zone(self):
+        """Current run is selected by timestamps, not list position."""
+        self.irrigation_service._get_schedule_runs = AsyncMock(
+            return_value={
+                "data": {
+                    "schedules": [
+                        {
+                            "schedule_state": "running",
+                            "schedule_name": "Morning Watering",
+                            "schedule_type": "FIXED",
+                            "zone_runs": [
+                                {
+                                    "zone_number": 1,
+                                    "zone_name": "Front Yard",
+                                    "start_ts": 1000,
+                                    "end_ts": 1100,
+                                },
+                                {
+                                    "zone_number": "2",
+                                    "zone_name": "Back Yard",
+                                    "start_ts": "1100",
+                                    "end_ts": "1200",
+                                },
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+
+        result = await self.irrigation_service.get_current_run(
+            self.test_irrigation, now_timestamp=1150
+        )
+
+        self.assertEqual(
+            result,
+            IrrigationRun(
+                zone_number=2,
+                zone_name="Back Yard",
+                start_ts=1100,
+                end_ts=1200,
+                schedule_name="Morning Watering",
+                schedule_type="FIXED",
+            ),
+        )
+
+    async def test_get_current_run_preserves_manual_type(self):
+        """Run-level schedule type is retained for HomeKit program mode."""
+        self.irrigation_service._get_schedule_runs = AsyncMock(
+            return_value={
+                "data": {
+                    "schedules": [
+                        {
+                            "schedule_state": "running",
+                            "schedule_name": "Quick Run",
+                            "zone_runs": [
+                                {
+                                    "zone_number": 1,
+                                    "zone_name": "Front Yard",
+                                    "start_ts": 1000,
+                                    "end_ts": 1200,
+                                    "schedule_type": "MANUAL",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+
+        result = await self.irrigation_service.get_current_run(
+            self.test_irrigation, now_timestamp=1100
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.schedule_type, "MANUAL")
+
+    async def test_get_current_run_does_not_guess_between_sequential_zones(self):
+        """No zone is reported when no interval is currently active."""
+        self.irrigation_service._get_schedule_runs = AsyncMock(
+            return_value={
+                "data": {
+                    "schedules": [
+                        {
+                            "schedule_state": "running",
+                            "zone_runs": [
+                                {
+                                    "zone_number": 1,
+                                    "start_ts": 1000,
+                                    "end_ts": 1100,
+                                },
+                                {
+                                    "zone_number": 2,
+                                    "start_ts": 1200,
+                                    "end_ts": 1300,
+                                },
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+
+        result = await self.irrigation_service.get_current_run(
+            self.test_irrigation, now_timestamp=1150
+        )
+
+        self.assertIsNone(result)
 
     async def test_get_schedule_runs_past_schedule(self):
         # Mock the _get_schedule_runs method


### PR DESCRIPTION
## Summary
Adds public typed irrigation runtime APIs:

- `get_current_run()` returns the active zone, timestamps, schedule name, and schedule type.
- `get_controller_info()` returns normalized controller settings.
- Fixes signed device-info requests to use the required `device_id`.
- Moves irrigation tests into the normal test suite.

## Motivation

The existing runtime method discards timer and schedule metadata and assumes the first zone in a program is active. Consumers otherwise need to access private authentication methods and parse raw Wyze responses themselves.

## Compatibility

This is additive. Existing `get_device_info()` and `get_schedule_runs()` return formats are preserved.

## Testing
- 263 tests pass.
- Ruff and formatting checks pass.
- Tested with a physical controller across idle, manual run, early stop, timer, and manual/scheduled mode transitions.

Related to #180, but exposes opt-in typed runtime data rather than mutating zone objects during every device update.