### PR TITLE
Add Wyze Scale cloud service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project will be documented in this file.
 See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## 0.7.0 - 2026-07-25
+
+### Features
+
+* Add Wyze Scale cloud service (latest weight / body composition records)
+
+- - -
 ## 0.6.1 - 2026-07-14
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wyzeapy"
-version = "0.6.1"
+version = "0.7.0"
 description = "A library for interacting with Wyze devices"
 authors = [
     { name = "Katie Mulliken", email = "katie@mulliken.net" },

--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -14,6 +14,7 @@ from .services.bulb_service import BulbService
 from .services.camera_service import CameraService
 from .services.hms_service import HMSService
 from .services.lock_service import LockService
+from .services.scale_service import ScaleService
 from .services.sensor_service import SensorService
 from .services.switch_service import SwitchService, SwitchUsageService
 from .services.thermostat_service import ThermostatService
@@ -54,6 +55,7 @@ class Wyzeapy:
         self._sensor_service = None
         self._irrigation_service = None
         self._air_purifier_service = None
+        self._scale_service = None
         self._wall_switch_service = None
         self._switch_usage_service = None
         self._email = None
@@ -461,6 +463,14 @@ class Wyzeapy:
         if self._air_purifier_service is None:
             self._air_purifier_service = AirPurifierService(self._auth_lib)
         return self._air_purifier_service
+
+    @property
+    async def scale_service(self) -> ScaleService:
+        """Returns an instance of the scale service"""
+
+        if self._scale_service is None:
+            self._scale_service = ScaleService(self._auth_lib)
+        return self._scale_service
 
     @property
     async def wall_switch_service(self) -> WallSwitchService:

--- a/src/wyzeapy/payload_factory.py
+++ b/src/wyzeapy/payload_factory.py
@@ -75,6 +75,22 @@ def olive_create_query_air_history_payload(
     }
 
 
+def olive_create_scale_get_payload(**params: Any) -> Dict[str, Any]:
+    """Build a GET payload for Wyze scale/pluto service endpoints.
+
+    Always includes a millisecond nonce. Caller-supplied params (e.g.
+    ``device_id``, ``family_member_id``, ``start_time``, ``end_time``) are
+    merged in after converting values to strings for signature stability.
+    """
+    nonce = int(time.time() * 1000)
+    payload: Dict[str, Any] = {"nonce": str(nonce)}
+    for key, value in params.items():
+        if value is None:
+            continue
+        payload[key] = str(value)
+    return payload
+
+
 def olive_create_get_payload_irrigation(device_mac: str) -> Dict[str, Any]:
     nonce = int(time.time() * 1000)
 

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -44,6 +44,7 @@ from ..payload_factory import (
     olive_create_post_payload_irrigation_stop,
     olive_create_post_payload_irrigation_quickrun,
     olive_create_get_payload_irrigation_schedule_runs,
+    olive_create_scale_get_payload,
 )
 from ..types import PropertyIDs, Device, DeviceMgmtToggleType
 from ..utils import (
@@ -1086,6 +1087,30 @@ class BaseService:
 
         payload = olive_create_get_payload_irrigation_schedule_runs(device.mac)
         payload["limit"] = limit
+        signature = olive_create_signature(payload, self._auth_lib.token.access_token)
+        headers = {
+            "Accept-Encoding": "gzip",
+            "User-Agent": "myapp",
+            "appid": OLIVE_APP_ID,
+            "appinfo": APP_INFO,
+            "phoneid": PHONE_ID,
+            "access_token": self._auth_lib.token.access_token,
+            "signature2": signature,
+        }
+
+        response_json = await self._auth_lib.get(url, headers=headers, params=payload)
+
+        check_for_errors_iot(self, response_json)
+
+        return response_json
+
+    async def _olive_get(
+        self, url: str, **params: Any
+    ) -> Dict[Any, Any]:
+        """Signed olive GET used by scale/pluto and similar plugin services."""
+        await self._auth_lib.refresh_if_should()
+
+        payload = olive_create_scale_get_payload(**params)
         signature = olive_create_signature(payload, self._auth_lib.token.access_token)
         headers = {
             "Accept-Encoding": "gzip",

--- a/src/wyzeapy/services/scale_service.py
+++ b/src/wyzeapy/services/scale_service.py
@@ -1,0 +1,223 @@
+#  Copyright (c) 2021. Mulliken, LLC - All Rights Reserved
+#  You may use, distribute and modify this code under the terms
+#  of the attached license. You should have received a copy of
+#  the license with this file. If not, please write to:
+#  katie@mulliken.net to receive a copy
+"""Wyze Scale cloud service (classic JA.SC* and pluto WL_SC*)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List
+
+from .base_service import BaseService
+from ..types import Device, DeviceTypes
+
+_LOGGER = logging.getLogger(__name__)
+
+SCALE_CLASSIC_MODELS = {"JA.SC", "JA.SC2"}
+SCALE_PLUTO_MODELS = {"WL_SC2", "WL_SC3", "WL_SCU", "WL_SCLET"}
+SCALE_MODELS = SCALE_CLASSIC_MODELS | SCALE_PLUTO_MODELS
+
+SCALE_SERVICE_BASE = "https://wyze-scale-service.wyzecam.com"
+PLUTO_SERVICE_BASE = "https://wyze-pluto-service.wyzecam.com"
+
+
+def _parse_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    # Wyze uses -1 as a sentinel for "not measured"
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _parse_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class ScaleRecord:
+    """A single weight / body-composition measurement from the Wyze cloud."""
+
+    def __init__(self, dictionary: Dict[Any, Any] | None = None) -> None:
+        data = dictionary or {}
+        self.data_id: str | None = (
+            str(data["data_id"]) if data.get("data_id") is not None else None
+        )
+        self.measure_ts: int | None = _parse_int(data.get("measure_ts"))
+        # API stores weight in kilograms
+        self.weight_kg: float | None = _parse_float(data.get("weight"))
+        self.bmi: float | None = _parse_float(data.get("bmi"))
+        self.body_fat: float | None = _parse_float(data.get("body_fat"))
+        self.muscle: float | None = _parse_float(data.get("muscle"))
+        self.body_water: float | None = _parse_float(data.get("body_water"))
+        self.bone_mineral: float | None = _parse_float(data.get("bone_mineral"))
+        self.protein: float | None = _parse_float(data.get("protein"))
+        self.bmr: float | None = _parse_float(data.get("bmr"))
+        self.heart_rate: int | None = _parse_int(data.get("heart_rate"))
+        self.metabolic_age: int | None = _parse_int(data.get("metabolic_age"))
+        family_member_id = data.get("family_member_id")
+        self.family_member_id: str | None = (
+            str(family_member_id) if family_member_id is not None else None
+        )
+        user_id = data.get("user_id")
+        self.user_id: str | None = str(user_id) if user_id is not None else None
+        self.mac: str | None = data.get("mac")
+
+
+class ScaleFamilyMember:
+    """A user profile associated with a Wyze scale."""
+
+    def __init__(self, dictionary: Dict[Any, Any]) -> None:
+        member_id = dictionary.get("id") or dictionary.get("family_member_id")
+        self.id: str = str(member_id) if member_id is not None else ""
+        self.nickname: str = str(dictionary.get("nickname") or "Unknown")
+        self.height: float | None = _parse_float(dictionary.get("height"))
+        self.goal_weight: float | None = _parse_float(dictionary.get("goal_weight"))
+
+
+class Scale(Device):
+    """Wyze Scale device with the latest cloud measurement."""
+
+    def __init__(self, dictionary: Dict[Any, Any]):
+        super().__init__(dictionary)
+        self.available: bool = True
+        self.unit: str | None = None
+        self.firmware_ver: str | None = dictionary.get("firmware_ver")
+        self.family_members: list[ScaleFamilyMember] = []
+        self.latest_record: ScaleRecord | None = None
+
+
+class ScaleService(BaseService):
+    """Service for listing Wyze scales and fetching measurement records."""
+
+    @staticmethod
+    def _is_pluto(scale: Scale) -> bool:
+        return scale.product_model in SCALE_PLUTO_MODELS
+
+    @classmethod
+    def _plugin_base(cls, scale: Scale) -> tuple[str, str]:
+        if cls._is_pluto(scale):
+            return PLUTO_SERVICE_BASE, "pluto"
+        return SCALE_SERVICE_BASE, "scale"
+
+    async def get_scales(self) -> List[Scale]:
+        """Return all Wyze scales on the account."""
+        if self._devices is None:
+            self._devices = await self.get_object_list()
+
+        scales = [
+            device
+            for device in self._devices
+            if device.type is DeviceTypes.SCALE
+            or device.product_model in SCALE_MODELS
+        ]
+        return [Scale(scale.raw_dict) for scale in scales]
+
+    async def update(self, scale: Scale) -> Scale:
+        """Refresh family members and the latest measurement for a scale."""
+        try:
+            scale.family_members = await self.get_family_members(scale)
+        except Exception:
+            _LOGGER.debug(
+                "Unable to fetch family members for %s", scale.nickname, exc_info=True
+            )
+
+        try:
+            scale.latest_record = await self.get_latest_record(scale)
+            scale.available = True
+        except Exception:
+            _LOGGER.warning(
+                "Unable to fetch latest record for %s", scale.nickname, exc_info=True
+            )
+            scale.available = False
+
+        return scale
+
+    async def get_family_members(self, scale: Scale) -> list[ScaleFamilyMember]:
+        """Fetch family member profiles linked to the scale."""
+        base, plugin = self._plugin_base(scale)
+        response = await self._olive_get(
+            f"{base}/plugin/{plugin}/get_family_member",
+            device_id=scale.mac,
+        )
+        data = response.get("data")
+        if not data:
+            return []
+        if isinstance(data, dict):
+            data = data.get("family_member_list") or data.get("list") or []
+        if not isinstance(data, list):
+            return []
+        return [ScaleFamilyMember(member) for member in data if isinstance(member, dict)]
+
+    async def get_latest_record(
+        self, scale: Scale, family_member_id: str | None = None
+    ) -> ScaleRecord | None:
+        """Fetch the most recent measurement for the account or a family member."""
+        base, plugin = self._plugin_base(scale)
+        params: Dict[str, Any] = {}
+        if family_member_id:
+            params["family_member_id"] = family_member_id
+
+        response = await self._olive_get(
+            f"{base}/plugin/{plugin}/get_latest_record",
+            **params,
+        )
+        return self._first_record(response.get("data"))
+
+    async def get_records(
+        self,
+        scale: Scale,
+        start_time: datetime,
+        end_time: datetime | None = None,
+        family_member_id: str | None = None,
+    ) -> list[ScaleRecord]:
+        """Fetch measurement history for a time range (timestamps in ms)."""
+        if end_time is None:
+            end_time = datetime.now()
+
+        base, plugin = self._plugin_base(scale)
+        params: Dict[str, Any] = {
+            "start_time": int(start_time.timestamp() * 1000),
+            "end_time": int(end_time.timestamp() * 1000),
+        }
+        if family_member_id:
+            params["family_member_id"] = family_member_id
+        if self._is_pluto(scale):
+            params["forward"] = 0
+
+        response = await self._olive_get(
+            f"{base}/plugin/{plugin}/get_record_range",
+            **params,
+        )
+        data = response.get("data")
+        if not data:
+            return []
+        if isinstance(data, dict):
+            data = [data]
+        if not isinstance(data, list):
+            return []
+        return [ScaleRecord(item) for item in data if isinstance(item, dict)]
+
+    @staticmethod
+    def _first_record(data: Any) -> ScaleRecord | None:
+        if data is None:
+            return None
+        if isinstance(data, list):
+            if not data:
+                return None
+            first = data[0]
+            return ScaleRecord(first) if isinstance(first, dict) else None
+        if isinstance(data, dict):
+            return ScaleRecord(data)
+        return None

--- a/tests/test_scale_service.py
+++ b/tests/test_scale_service.py
@@ -1,0 +1,194 @@
+import unittest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from wyzeapy.services.scale_service import (
+    SCALE_MODELS,
+    Scale,
+    ScaleRecord,
+    ScaleService,
+)
+from wyzeapy.types import DeviceTypes
+from wyzeapy.wyze_auth_lib import WyzeAuthLib
+
+
+class TestScaleService(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.mock_auth_lib = MagicMock(spec=WyzeAuthLib)
+        self.scale_service = ScaleService(auth_lib=self.mock_auth_lib)
+        self.scale_service.get_object_list = AsyncMock()
+        self.scale_service._olive_get = AsyncMock()
+
+        self.test_scale = Scale(
+            {
+                "product_type": DeviceTypes.SCALE.value,
+                "product_model": "JA.SC",
+                "mac": "JA.SC.ABCDEF123456",
+                "nickname": "Test Scale",
+                "device_params": {},
+                "raw_dict": {},
+            }
+        )
+
+    async def test_get_scales_filters_models(self):
+        scale_device = Scale(
+            {
+                "product_type": DeviceTypes.SCALE.value,
+                "product_model": "JA.SC",
+                "mac": "JA.SC.111",
+                "nickname": "Scale",
+                "device_params": {},
+            }
+        )
+        bulb = MagicMock()
+        bulb.type = DeviceTypes.LIGHT
+        bulb.product_model = "WLPA19"
+        bulb.raw_dict = {
+            "product_type": "Light",
+            "product_model": "WLPA19",
+            "mac": "BULB1",
+            "nickname": "Bulb",
+            "device_params": {},
+        }
+        pluto = Scale(
+            {
+                "product_type": "Common",
+                "product_model": "WL_SC2",
+                "mac": "WL_SC2.222",
+                "nickname": "Scale S",
+                "device_params": {},
+            }
+        )
+
+        self.scale_service.get_object_list.return_value = [scale_device, bulb, pluto]
+
+        scales = await self.scale_service.get_scales()
+
+        self.assertEqual(len(scales), 2)
+        self.assertEqual(scales[0].mac, "JA.SC.111")
+        self.assertEqual(scales[1].mac, "WL_SC2.222")
+        self.assertTrue(SCALE_MODELS.issuperset({"JA.SC", "WL_SC2"}))
+
+    async def test_update_maps_latest_record(self):
+        self.scale_service._olive_get.side_effect = [
+            {
+                "data": [
+                    {
+                        "id": "member1",
+                        "nickname": "Chee",
+                        "height": 175.0,
+                        "goal_weight": 70.0,
+                    }
+                ]
+            },
+            {
+                "data": [
+                    {
+                        "data_id": "rec1",
+                        "measure_ts": 1700000000000,
+                        "weight": 80.5,
+                        "bmi": 24.1,
+                        "body_fat": 18.5,
+                        "muscle": 59.0,
+                        "body_water": -1,
+                        "heart_rate": None,
+                    }
+                ]
+            },
+        ]
+
+        updated = await self.scale_service.update(self.test_scale)
+
+        self.assertTrue(updated.available)
+        self.assertEqual(len(updated.family_members), 1)
+        self.assertEqual(updated.family_members[0].nickname, "Chee")
+        self.assertIsNotNone(updated.latest_record)
+        assert updated.latest_record is not None
+        self.assertEqual(updated.latest_record.weight_kg, 80.5)
+        self.assertEqual(updated.latest_record.bmi, 24.1)
+        self.assertEqual(updated.latest_record.body_fat, 18.5)
+        self.assertEqual(updated.latest_record.muscle, 59.0)
+        self.assertIsNone(updated.latest_record.body_water)
+        self.assertEqual(
+            self.scale_service._olive_get.await_args_list[0].args[0],
+            "https://wyze-scale-service.wyzecam.com/plugin/scale/get_family_member",
+        )
+        self.assertEqual(
+            self.scale_service._olive_get.await_args_list[1].args[0],
+            "https://wyze-scale-service.wyzecam.com/plugin/scale/get_latest_record",
+        )
+
+    async def test_update_uses_pluto_urls(self):
+        pluto_scale = Scale(
+            {
+                "product_type": DeviceTypes.SCALE.value,
+                "product_model": "WL_SC2",
+                "mac": "WL_SC2.ABCDEF",
+                "nickname": "Scale S",
+                "device_params": {},
+            }
+        )
+        self.scale_service._olive_get.side_effect = [
+            {"data": []},
+            {"data": {"weight": 70.0, "bmi": 22.0, "measure_ts": 1}},
+        ]
+
+        await self.scale_service.update(pluto_scale)
+
+        self.assertEqual(
+            self.scale_service._olive_get.await_args_list[0].args[0],
+            "https://wyze-pluto-service.wyzecam.com/plugin/pluto/get_family_member",
+        )
+        self.assertEqual(
+            self.scale_service._olive_get.await_args_list[1].args[0],
+            "https://wyze-pluto-service.wyzecam.com/plugin/pluto/get_latest_record",
+        )
+
+    async def test_update_empty_latest_record(self):
+        self.scale_service._olive_get.side_effect = [
+            {"data": []},
+            {"data": []},
+        ]
+
+        updated = await self.scale_service.update(self.test_scale)
+
+        self.assertTrue(updated.available)
+        self.assertIsNone(updated.latest_record)
+
+    async def test_get_records_range(self):
+        self.scale_service._olive_get.return_value = {
+            "data": [
+                {"weight": 80.0, "bmi": 24.0, "measure_ts": 100},
+                {"weight": 81.0, "bmi": 24.2, "measure_ts": 200},
+            ]
+        }
+
+        records = await self.scale_service.get_records(
+            self.test_scale,
+            start_time=datetime(2024, 1, 1),
+            end_time=datetime(2024, 1, 31),
+        )
+
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0].weight_kg, 80.0)
+        call_kwargs = self.scale_service._olive_get.await_args.kwargs
+        self.assertIn("start_time", call_kwargs)
+        self.assertIn("end_time", call_kwargs)
+
+    def test_scale_record_sentinel_values(self):
+        record = ScaleRecord(
+            {
+                "weight": 70.0,
+                "body_fat": -1,
+                "muscle": -1.0,
+                "bmi": 22.5,
+            }
+        )
+        self.assertEqual(record.weight_kg, 70.0)
+        self.assertEqual(record.bmi, 22.5)
+        self.assertIsNone(record.body_fat)
+        self.assertIsNone(record.muscle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wyzeapy.py
+++ b/tests/test_wyzeapy.py
@@ -236,6 +236,15 @@ async def test_air_purifier_service(mock_auth_lib):
 
 
 @pytest.mark.asyncio
+async def test_scale_service(mock_auth_lib):
+    wyze = await Wyzeapy.create()
+    await wyze.login("test@example.com", "password", "key_id", "api_key")
+    service = await wyze.scale_service
+    assert service is not None
+    assert wyze._scale_service is service
+
+
+@pytest.mark.asyncio
 async def test_hms_service(mock_auth_lib):
     wyze = await Wyzeapy.create()
     await wyze.login("test@example.com", "password", "key_id", "api_key")

--- a/uv.lock
+++ b/uv.lock
@@ -790,7 +790,7 @@ wheels = [
 
 [[package]]
 name = "wyzeapy"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## Summary
- Add `ScaleService` for classic (`JA.SC` / `JA.SC2`) and pluto (`WL_SC*`) Wyze scales
- Fetch family members and latest weight / body-composition records via olive-signed GETs
- Bump version to 0.7.0

## Test plan
- [x] Unit tests in `tests/test_scale_service.py`
- [x] Live login against JA.SC and WL_SCU accounts returned latest weight/BMI/body fat
- [ ] Reviewer: confirm olive signing matches other plugin services

Refs: SecKatie/ha-wyzeapi#93, SecKatie/ha-wyzeapi#617