### PR TITLE
fix: build the SSL context off the event loop

### DIFF
--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -45,11 +45,33 @@ _EXTRA_CA_BUNDLE = Path(__file__).with_name("wyze_api_ca.pem")
 
 @cache
 def get_ssl_context() -> ssl.SSLContext:
-    """Return an SSL context containing system, certifi, and Wyze CA roots."""
+    """Return an SSL context containing system, certifi, and Wyze CA roots.
+
+    This reads certificate bundles from disk, so it blocks. Callers running
+    inside an event loop should use :func:`async_get_ssl_context` instead.
+    """
     context = ssl.create_default_context()
     context.load_verify_locations(cafile=certifi.where())
     context.load_verify_locations(cafile=_EXTRA_CA_BUNDLE)
     return context
+
+
+async def async_get_ssl_context() -> ssl.SSLContext:
+    """Return the shared SSL context, building it off the event loop.
+
+    Building the context reads three certificate bundles from disk
+    (``create_default_context`` loads the system store, then certifi's bundle
+    and the Wyze CA bundle are loaded on top). That is blocking I/O, and doing
+    it inline stalls the caller's event loop. Home Assistant detects this and
+    logs a "Detected blocking call to load_default_certs ... inside the event
+    loop" warning naming this library.
+
+    Because :func:`get_ssl_context` is ``@cache``-decorated, awaiting this once
+    populates the cache from a worker thread; every later call, including the
+    synchronous ones in :func:`_create_client_session`, then returns the
+    memoized context without touching the filesystem.
+    """
+    return await asyncio.to_thread(get_ssl_context)
 
 
 def _create_client_session() -> ClientSession:
@@ -194,6 +216,12 @@ class WyzeAuthLib:
         ):
             assert self._username != ""
             assert self._password != ""
+
+        # Build the SSL context here, in a worker thread, while we are in async
+        # context. Every request path below reaches get_ssl_context() from
+        # synchronous code, so without this the one-time disk read happens on
+        # the caller's event loop.
+        await async_get_ssl_context()
 
         return self
 

--- a/tests/test_wyze_auth_lib.py
+++ b/tests/test_wyze_auth_lib.py
@@ -1,5 +1,6 @@
 from hashlib import sha256
 import ssl
+import threading
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
 from wyzeapy.wyze_auth_lib import (
@@ -9,6 +10,7 @@ from wyzeapy.wyze_auth_lib import (
     AccessTokenError,
     UnknownApiError,
     get_ssl_context,
+    async_get_ssl_context,
 )
 import time
 import aiohttp  # Import aiohttp
@@ -31,6 +33,39 @@ class TestWyzeAuthLib(unittest.IsolatedAsyncioTestCase):
             "4348a0e9444c78cb265e058d5e8944b4d84f9662bd26db257f8934a443c70161",
             fingerprints,
         )
+
+    async def test_async_ssl_context_returns_the_cached_context(self):
+        self.assertIs(await async_get_ssl_context(), get_ssl_context())
+
+    async def test_async_ssl_context_builds_off_the_event_loop(self):
+        """The blocking cert load must happen in a worker thread, not the loop."""
+        get_ssl_context.cache_clear()
+        self.addCleanup(get_ssl_context.cache_clear)
+
+        loop_thread = threading.get_ident()
+        build_threads = []
+        real_create_default_context = ssl.create_default_context
+
+        def recording_create_default_context(*args, **kwargs):
+            build_threads.append(threading.get_ident())
+            return real_create_default_context(*args, **kwargs)
+
+        with patch(
+            "wyzeapy.wyze_auth_lib.ssl.create_default_context",
+            side_effect=recording_create_default_context,
+        ):
+            await async_get_ssl_context()
+
+        self.assertEqual(len(build_threads), 1)
+        self.assertNotEqual(build_threads[0], loop_thread)
+
+    async def test_create_warms_the_ssl_context_cache(self):
+        get_ssl_context.cache_clear()
+        self.addCleanup(get_ssl_context.cache_clear)
+
+        await WyzeAuthLib.create(username="test_user", password="test_password")
+
+        self.assertEqual(get_ssl_context.cache_info().currsize, 1)
 
     def test_initialization(self):
         auth_lib = WyzeAuthLib(username="test_user", password="test_password")


### PR DESCRIPTION
Home Assistant logs this on every startup, naming this library and asking for a bug report:

```
Detected blocking call to load_default_certs with args (<ssl.SSLContext object>, <Purpose.SERVER_AUTH>)
inside the event loop by custom integration 'wyzeapi' at custom_components/wyzeapi/__init__.py, line 122:
await client.login( (offender: /usr/local/lib/python3.14/ssl.py, line 722: context.load_default_certs(purpose)),
please create a bug report at https://github.com/SecKatie/ha-wyzeapi/issues
```

Three of them fire per startup: `load_default_certs`, `set_default_verify_paths`, and `load_verify_locations` for both `certifi.where()` and `wyze_api_ca.pem`.

## Cause

`get_ssl_context()` reads three certificate bundles from disk. Every path that reaches it does so from synchronous code inside `_create_client_session()`, which itself is called from coroutines, so the first build happens inline on the caller's event loop and stalls it.

## Fix

Add `async_get_ssl_context()`, which runs the build in a worker thread via `asyncio.to_thread()`, and await it once in `WyzeAuthLib.create()`.

Since `get_ssl_context()` is `@cache`-decorated, warming it there means every later synchronous call returns the memoized context without touching the filesystem. The loop is never blocked, and the hot path stays synchronous and allocation-free.

`get_ssl_context()` keeps its signature and behaviour, so synchronous callers are unaffected.

## Why it is worth fixing now

Home Assistant has been progressively turning these warnings into hard errors. Right now it is log noise on every startup for every HA user of the integration; when it is promoted, it becomes a failure.

## Testing

Three tests added to `tests/test_wyze_auth_lib.py`:

- `async_get_ssl_context()` returns the same cached object as `get_ssl_context()`
- the build runs on a different thread than the event loop (patches `ssl.create_default_context` and records `threading.get_ident()`)
- `WyzeAuthLib.create()` leaves the cache warm (`cache_info().currsize == 1`)

Both behaviours are mutation-tested: reverting `asyncio.to_thread` to a direct call fails the off-loop test, and removing the warm-up from `create()` fails the cache test.

`uv run ruff check src/`, `uv run ruff format --check src/` and `uv run pytest tests/` all pass (232 tests).